### PR TITLE
Add hiero-did-sdk-python

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -219,6 +219,17 @@ teams:
       - nadineloepfe
     members:
       - exploreriii
+  - name: hiero-did-sdk-python-maintainers
+    maintainers:
+      - Reccetech
+    members:
+      - AlexanderShenshin
+      - dmueller2001
+  - name: hiero-did-sdk-python-committers
+    maintainers:
+      - Reccetech
+    members:
+      - paulo-caldas-code
   - name: hiero-sdk-rust-maintainers
     maintainers:
       - RickyLB
@@ -538,6 +549,14 @@ repositories:
       github-committers: write
       hiero-sdk-python-maintainers: maintain
       hiero-sdk-python-committers: write
+    visibility: public
+  - name: hiero-did-sdk-python
+    teams:
+      tsc: maintain
+      github-maintainers: admin
+      github-committers: write
+      hiero-did-sdk-python-maintainers: maintain
+      hiero-did-sdk-python-committers: write
     visibility: public
   - name: hiero-docs
     teams:


### PR DESCRIPTION
Added `hiero-did-sdk-python` repo and corresponding maintainers and committers groups.

Project proposal link: https://github.com/hiero-ledger/tsc/issues/81

Please note that repo naming differs from initially proposed: `did-sdk-py` -> `hiero-did-sdk-python` (for consistency with other SDKs).
