### PR TITLE
chore: add maintainer to committer group

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,7 @@ teams:
       - rbarker-dev
       - nathanklick
     members:
+      - andrewb1269hg
       - hendrikebbers
       - PavelSBorisov
   - name: community


### PR DESCRIPTION
**Description**:

Add `andrewb1269hg` to `github-committers` group.

**Related Issue(s)**:

Fixes #127