### PR TITLE
chore: hiero-gradle-conventions-maintainers access sdk-java / remove jjohaness from hiero-block-node

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -351,7 +351,6 @@ teams:
       - san-est
       - rbair23
       - mishomihov00
-      - jjohannes
       - a-saksena
       - CMiville42
       - mattp-swirldslabs
@@ -663,6 +662,7 @@ repositories:
       github-committers: write
       hiero-sdk-java-maintainers: maintain
       hiero-sdk-java-committers: write
+      hiero-gradle-conventions-maintainers: write
     visibility: public
   - name: hiero-sdk-js
     teams:


### PR DESCRIPTION
**Description**:

- With this, **hiero-gradle-conventions-maintainers** (which includes _jjohannes_) have write access for all repos that use the Gradle Conventions.
- _jjohannes_ does not need to be a direct maintainer to hiero-block-node as he already has write access through **hiero-gradle-conventions-maintainers**
