### PR TITLE
chore: Add team hcn-execution-internal-contributors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -447,6 +447,7 @@ teams:
     maintainers:
       - netopyr
     members:
+      - akdev
       - elpinkypie
   - name: hcn-consensus-maintainers
     maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -443,6 +443,11 @@ teams:
       - povolev15
       - thomas-swirlds-labs
       - vtronkov
+  - name: hcn-execution-internal-contributors
+    maintainers:
+      - netopyr
+    members:
+      - elpinkypie
   - name: hcn-consensus-maintainers
     maintainers:
       - poulok
@@ -714,6 +719,7 @@ repositories:
       hcn-execution-maintainers: maintain
       hcn-execution-committers: write
       hcn-execution-codeowners: write
+      hcn-execution-internal-contributors: triage
       hcn-consensus-maintainers: maintain
       hcn-consensus-committers: write
       hcn-consensus-codeowners: write


### PR DESCRIPTION
**Description**:

Per [RESD-111](https://swirldslabs.atlassian.net/browse/RESD-111)

- [x] Add team `hcn-execution-internal-contributors`
- [x] Add user: elpinkypie to this team
- [x] Add user: akdev to this team
- [x] Add team to hiero-consensus-node with `triage` permission

