### PR TITLE
chore: revert accidental changes to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -400,7 +400,7 @@ teams:
       - allison-hashgraph
   - name: hcn-execution-maintainers
     maintainers:
-      - Nana-EC
+      - netopyr
     members:
       - Neeharika-Sompalli
       - tinker-michaelj
@@ -410,7 +410,6 @@ teams:
       - netopyr
       - tinker-michaelj
     members:
-      - akdev
       - anastasiya-kovaliova
       - derektriley
       - Evdokia-Georgieva


### PR DESCRIPTION
**Description**:

Reverts change to hcn-execution-maintainers to place user, netopyr, as the maintainer. This change occurred erroneously.

Reverts change adding akdev to hcn-execution-committers. This change occurred as part of RESD-112. RESD-111 provides additional context. User akdev will be brought back in to an internal team as part of PR #147
