### PR TITLE
Add JSON RPC relay groups

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -601,6 +601,33 @@ teams:
       - alex-kuzmin-hg
       - OlegMazurov
       - JeffreyDallas
+  - name: hiero-json-rpc-relay-maintainers
+    maintainers:
+      - Ferparishuertas
+      - Nana-EC
+    members:
+      - AlfredoG87
+      - georgi-l95
+      - quiet-node
+  - name: hiero-json-rpc-relay-committers
+    maintainers:
+      - Ferparishuertas
+      - Nana-EC
+    members:
+      - acuarica
+      - AlfredoG87
+      - arianejasuwienas
+      - dimitrovmaksim
+      - ebadiere
+      - georgi-l95
+      - isavov
+      - Ivo-Yankov
+      - konstantinabl
+      - lukelee-sl
+      - natanasow
+      - quiet-node
+      - simzzz
+      - victor-yanev
 repositories:
   - name: governance
     teams:


### PR DESCRIPTION
**Description**:
Add JSON RPC relay groups
List preserves maintain and committers who've made honorable commits in the past few years

**Related issue(s)**:

Fixes [43](https://github.com/hiero-ledger/tsc/issues/43)

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
