### PR TITLE
add maintainers and members for hiero improvement proposals

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,7 +75,6 @@ teams:
       - ebadiere
       - ed-marquez
       - edward-swirldslabs
-      - EMerchant90
       - ericleponner
       - failfmi
       - fakepaulbugeja
@@ -631,13 +630,13 @@ teams:
       - victor-yanev
   - name: hiero-improvement-proposal-maintainers
     maintainers:
-      - EMerchant90
+      - sergmetelin
       - mgarbs
       - RaphaelMessian
     members: []
   - name: hiero-improvement-proposal-committers
     maintainers:
-      - EMerchant90
+      - sergmetelin
       - mgarbs
       - RaphaelMessian
     members:

--- a/config.yaml
+++ b/config.yaml
@@ -702,7 +702,6 @@ teams:
       - qnswirlds
       - rahul-kothari
       - rocketmay
-      - sergmetelin
       - tannerjfco
       - tim-mchale
       - tmctl

--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,7 @@ teams:
       - ebadiere
       - ed-marquez
       - edward-swirldslabs
+      - EMerchant90
       - ericleponner
       - failfmi
       - fakepaulbugeja

--- a/config.yaml
+++ b/config.yaml
@@ -628,6 +628,109 @@ teams:
       - quiet-node
       - simzzz
       - victor-yanev
+  - name: hiero-improvement-proposal-maintainers
+    maintainers:
+      - EMerchant90
+      - mgarbs
+      - RaphaelMessian
+    members: []
+  - name: hiero-improvement-proposal-committers
+    maintainers:
+      - EMerchant90
+      - mgarbs
+      - RaphaelMessian
+    members:
+      - mgarbs
+      - swirlds-automation
+      - kenthejr
+      - Daniel-K-Ivanov
+      - lbaird
+      - Cooper-Kunz
+      - shemnon
+      - SimiHunjan
+      - Nana-EC
+      - dependabot[bot]
+      - failfmi
+      - steven-sheehy
+      - stoqnkpL
+      - publu
+      - netopyr
+      - michielmulders
+      - rbarker-dev
+      - tinker-michaelj
+      - lukelee-sl
+      - mustafauzunn
+      - IvanKavaldzhiev
+      - MiroslavGatsanoga
+      - statop
+      - Neeharika-Sompalli
+      - Neurone
+      - H-Bart
+      - bugbytesinc
+      - sam-at-luther
+      - Mark-Swirlds
+      - mgoelswirlds
+      - kimbor
+      - edward-swirldslabs
+      - superboo
+      - scalemaildev
+      - itsbrandondev
+      - donaldthibeau
+      - danielnorkin
+      - ty-swirldslabs
+      - stoyanov-st
+      - rbair23
+      - kantorcodes
+      - lucashenning
+      - david-bakin-sl
+      - janaakhterov
+      - anighanta
+      - paulatcalaxy
+      - jayv80
+      - gregscullard
+      - mehcode
+      - RECDeFi
+      - jsync-swirlds
+      - iwsimon
+      - georgi-l95
+      - bguiz
+      - Ashe-Oro
+      - AliNik4n
+      - raykhoaza
+      - dimitrovmaksim
+      - nickpoorman
+      - petreze
+      - qnswirlds
+      - rahul-kothari
+      - rocketmay
+      - sergmetelin
+      - tannerjfco
+      - tim-mchale
+      - tmctl
+      - anvabr
+      - justin-atwell
+      - littletarzan
+      - se7enarianelabs
+      - som-web23
+      - sumapnair-ibm
+      - andrewb1269hg
+      - mcbosserton
+      - cacampbell
+      - soharang
+      - chung-chao
+      - cijujohn
+      - derektriley
+      - dimitar-dinev
+      - edwin-greene
+      - EvelynLWong
+      - fessmm
+      - gerbert-vandenberghe
+      - cmdhema
+      - Ivo-Yankov
+      - jascks
+      - jnels124
+      - justynspooner
+      - Reccetech
 repositories:
   - name: governance
     teams:
@@ -805,4 +908,12 @@ repositories:
       github-committers: write
       hiero-sdk-rust-maintainers: maintain
       hiero-sdk-rust-committers: write
+    visibility: public
+  - name: hiero-improvement-proposal
+    teams:
+      tsc: maintain
+      github-maintainers: admin
+      github-committers: write
+      hiero-improvement-proposal-maintainers: maintain
+      hiero-improvement-proposal-committers: write
     visibility: public

--- a/config.yaml
+++ b/config.yaml
@@ -907,11 +907,3 @@ repositories:
       hiero-sdk-rust-maintainers: maintain
       hiero-sdk-rust-committers: write
     visibility: public
-  - name: hiero-improvement-proposal
-    teams:
-      tsc: maintain
-      github-maintainers: admin
-      github-committers: write
-      hiero-improvement-proposal-maintainers: maintain
-      hiero-improvement-proposal-committers: write
-    visibility: public

--- a/config.yaml
+++ b/config.yaml
@@ -640,7 +640,6 @@ teams:
       - mgarbs
       - RaphaelMessian
     members:
-      - mgarbs
       - swirlds-automation
       - kenthejr
       - Daniel-K-Ivanov


### PR DESCRIPTION
# Add Hiero Improvement Proposal Teams and Repository

This PR adds the required configuration for the new Hiero Improvement Proposal repository:

- Creates `hiero-improvement-proposal-maintainers` team with EMerchant90, mgarbs, and RaphaelMessian as maintainers
- Creates `hiero-improvement-proposal-committers` team with the same maintainers plus appropriate members
- Adds repository configuration with proper team permissions

This follows the standard governance pattern established for other Hiero projects.