### PR TITLE
chore: Removing Engineers from Hiero Teams 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -392,14 +392,10 @@ teams:
       - rbarker-dev
       - nathanklick
     members:
-      - kimbor
       - derektriley
-      - povolev15
       - tinker-michaelj
       - Neeharika-Sompalli
       - mhess-swl
-      - iwsimon
-      - thomas-swirlds-labs
   - name: hcn-devops-codeowners
     maintainers:
       - dalvizu

--- a/config.yaml
+++ b/config.yaml
@@ -338,7 +338,6 @@ teams:
       - Nana-EC
     members:
       - AlfredoG87
-      - mattp-swirldslabs
   - name: hiero-block-node-committers
     maintainers:
       - AlfredoG87
@@ -352,7 +351,6 @@ teams:
       - rbair23
       - a-saksena
       - CMiville42
-      - mattp-swirldslabs
   - name: hiero-consensus-node-maintainers
     maintainers:
       - Nana-EC
@@ -425,14 +423,10 @@ teams:
       - derektriley
       - Evdokia-Georgieva
       - ibankov
-      - iwsimon
       - JivkoKelchev
-      - kimbor
       - mhess-swl
       - MiroslavGatsanoga
       - petreze
-      - povolev15
-      - thomas-swirlds-labs
       - vtronkov
       - jsync-swirlds
   - name: hcn-execution-codeowners
@@ -445,14 +439,10 @@ teams:
       - derektriley
       - Evdokia-Georgieva
       - ibankov
-      - iwsimon
       - JivkoKelchev
-      - kimbor
       - mhess-swl
       - MiroslavGatsanoga
       - petreze
-      - povolev15
-      - thomas-swirlds-labs
       - vtronkov
   - name: hcn-execution-internal-contributors
     maintainers:
@@ -555,14 +545,10 @@ teams:
       - derektriley
       - Evdokia-Georgieva
       - ibankov
-      - iwsimon
       - JivkoKelchev
-      - kimbor
       - mhess-swl
       - MiroslavGatsanoga
       - petreze
-      - povolev15
-      - thomas-swirlds-labs
       - vtronkov
   - name: hiero-docs-maintainers
     maintainers:


### PR DESCRIPTION
Certain members of the below teams recently left Hashgraph. We will need to vote to decide to remove them from their permissions file. 

A 2/3rds vote is required to remove these individuals.



hcn-release-engineers
hcn-execution-committers
hcn-execution-codeowners
hiero-protobufs-committers
hiero-block-node-maintainers
hiero-block-node-committers