### PR TITLE
Chore: Rename "End User Electors" to "Adopters"

### DIFF
--- a/elections/ADOPTERS.md
+++ b/elections/ADOPTERS.md
@@ -1,6 +1,6 @@
-# End User Electors
+# Adopters
 
-This document lists each approved elector capable of casting a vote for candidates for the End User Seat on the TSC.
+This document lists each approved elector capable of casting a vote for candidates for the Adopters Seat on the TSC.
 Each entry in this file must contain:
 - The name of the project or business
 - The public Hiero ledger with an account for the elector (e.g. Hedera)
@@ -8,8 +8,7 @@ Each entry in this file must contain:
 - A link to the website for the project or business
 - A statement describing the role of this project or business within the Hiero ecosystem
 
-It is a violation of the rules of the election for any one elector to vote more than once in an End User Seat
-election.
+It is a violation of the rules of the election for any one elector to vote more than once in an Adopters Seat election.
 
 ## Electors
 


### PR DESCRIPTION
This change is to bring consistency across how this file is named in other communities.
