### PR TITLE
Add HashPack Inc. as adopter and May Chan nomination

### DIFF
--- a/elections/ADOPTERS.md
+++ b/elections/ADOPTERS.md
@@ -1,6 +1,11 @@
 # Adopters
 
-This document lists each approved elector capable of casting a vote for candidates for the Adopters Seat on the TSC.
+Adopters of the Hiero project are any organization that successfully leverages the Hiero project in the manner it was intended or repackages it as a core component of a service offering. If your organization is deploying an application or service on a Hiero-based network or hosting a Hiero-based network in your organization, please add your company name to this list. 
+
+The Hiero TSC’s intent in identifying adopters is to better understand the operational or production-level use of the Hiero project by its operators or users. We do this to ascertain the level of maturity the project has reached, its interactions with adopters, and its likelihood to continue growing within and supporting the ecosystem. Original sponsoring organizations, if any, may be included in the ADOPTERS.md file. 
+
+In addition, the organizations listed within this document will be used to identify the list of organizations' approved electors capable of casting a vote for candidates for the End User Seat on the Hiero TSC.
+
 Each entry in this file must contain:
 - The name of the project or business
 - The public Hiero ledger with an account for the elector (e.g. Hedera)

--- a/elections/ADOPTERS.md
+++ b/elections/ADOPTERS.md
@@ -19,3 +19,4 @@ It is a violation of the rules of the election for any one elector to vote more 
 
 | Name                     | Public Ledger | Account       | Link                          | Statement                               |
 |--------------------------|---------------|---------------|-------------------------------|-----------------------------------------|
+| HashPack Inc. | Hedera | 0.0.8596411 | https://www.hashpack.app | HashPack is a pioneering force in the Hedera ecosystem since 2020, developing critical infrastructure that enabled the growth of Hedera's retail DeFi ecosystem. As builders of wallet technology used by 95% of Hedera's retail users, HashPack brings essential perspective on user experience, developer needs, and technical implementation challenges that will inform Hiero's development priorities and adoption strategy. |

--- a/elections/nominees/mar-2025-election/may-chan.md
+++ b/elections/nominees/mar-2025-election/may-chan.md
@@ -1,0 +1,17 @@
+**Nomination**
+
+**Candidate**
+May Chan
+
+**Qualifications**
+May has been a member of the Hedera ecosystem since 2021. She is the CEO and Co-Founder of HashPack, which was founded in May 2020 and launched in the Hedera Ecosystem in October 2020. Since its founding, HashPack has been a leader in the Hedera ecosystem. HashPack built the first signing library on the network (HashConnect), which catalyzed the entire retail defi ecosystem. Since then HashPack has worked closely with Hedera and the community, leading ecosystem initiatives such as smart contract support, native staking and many others. As of May 2025, HashPack's user base represents 95% of the Hedera retail ecosystem
+
+On an individual level, May has been deeply involved in all levels of the community. May is a well-recognized spokesperson in the Hedera community, and has shared her story and insights at many Hedera events and in numerous interviews, podcasts and spaces. May was present at HederaCon 2025 in Denver, where she spoke on two panels on the main stage, in addition to her company's sponsorship of a booth.
+
+May wrote and led the adoption of HIP-412, which sets the metadata schema for every NFT in the Hedera ecosystem, and has contributed on numerous HIPs (Hedera improvement proposals) over the past four years. More recently she has been an active contributor in the DeRec Alliance and is writing the Typescript implementation library with the help of Richard Goodhue and the rest of the alliance contributors.
+
+As a TSC member, May would leverage her extensive network of users, developers, and companies across the Hedera ecosystem to ensure the technical direction of Hiero remains aligned with real-world implementation needs. Her unique perspective as CEO of HashPack provides direct insight into user experience challenges and opportunities, which would inform technical decisions with practical feedback loops. May's demonstrated commitment to open standards through her work on HIP-412 and the DeRec Alliance reflects her collaborative approach to ecosystem development—an approach she would bring to the Technical Steering Committee to help Hiero achieve wider adoption and continued technical excellence.
+
+**Statement**
+
+I would be honored to serve on the Technical Steering Committee for Hiero. Having witnessed and contributed to Hedera's growth since 2021, I am deeply committed to its continued technical excellence and adoption. My experience building essential infrastructure for the ecosystem has given me valuable perspective on both the technical challenges and practical needs of Hedera's diverse stakeholders. If selected, I would bring my collaborative approach, technical insights, and community connections to help guide Hiero's development in a way that serves developers, users, and the broader ecosystem. I am excited about the opportunity to contribute to Hedera's technical governance and help shape its future direction.


### PR DESCRIPTION
**Description**:
Add HashPack Inc. to ADOPTERS.md and submit May Chan's nomination for the Technical Steering Committee

- Add HashPack Inc. entry to the Electors table in ADOPTERS.md
- Create May Chan's nomination file with qualifications and statement

**Related issue(s)**:

N/A

**Notes for reviewer**:
HashPack Inc. has been an active participant in the Hedera ecosystem since 2020, and May Chan, as CEO and co-founder, has contributed significantly to the community through technical standards work including HIP-412 and DeRec Alliance contributions. This PR adds HashPack as an elector organization and submits May's nomination for the TSC.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
