### PR TITLE
chore: reorder json rpc group reorder

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -597,6 +597,7 @@ teams:
   - name: hiero-json-rpc-relay-maintainers
     maintainers:
       - Ferparishuertas
+      - Nana-EC
     members:
       - acuarica
       - konstantinabl

--- a/config.yaml
+++ b/config.yaml
@@ -508,6 +508,7 @@ teams:
   - name: hcn-smart-contract-codeowners
     maintainers:
       - Ferparishuertas
+      - Nana-EC
     members:
       - lukelee-sl
       - david-bakin-sl

--- a/config.yaml
+++ b/config.yaml
@@ -492,28 +492,27 @@ teams:
       - abies
   - name: hcn-smart-contract-maintainers
     maintainers:
-      - Nana-EC
       - Ferparishuertas
     members:
       - lukelee-sl
+      - bubo
+      - stoyanov-st
   - name: hcn-smart-contract-committers
     maintainers:
-      - Nana-EC
       - Ferparishuertas
     members:
       - david-bakin-sl
       - bubo
+      - Nana-EC
       - stoqnkpL
       - stoyanov-st
+      - lukelee-sl
   - name: hcn-smart-contract-codeowners
     maintainers:
-      - Nana-EC
       - Ferparishuertas
     members:
       - lukelee-sl
-      - david-bakin-sl
       - bubo
-      - stoqnkpL
       - stoyanov-st
   - name: hcn-tools-and-libs-maintainers
     maintainers:
@@ -598,11 +597,12 @@ teams:
   - name: hiero-json-rpc-relay-maintainers
     maintainers:
       - Ferparishuertas
-      - Nana-EC
     members:
-      - AlfredoG87
-      - georgi-l95
+      - acuarica
+      - konstantinabl
       - quiet-node
+      - simzzz
+      - natanasow
   - name: hiero-json-rpc-relay-committers
     maintainers:
       - Ferparishuertas

--- a/config.yaml
+++ b/config.yaml
@@ -492,27 +492,27 @@ teams:
       - abies
   - name: hcn-smart-contract-maintainers
     maintainers:
+      - Nana-EC
       - Ferparishuertas
     members:
       - lukelee-sl
-      - bubo
-      - stoyanov-st
   - name: hcn-smart-contract-committers
     maintainers:
+      - Nana-EC
       - Ferparishuertas
     members:
       - david-bakin-sl
       - bubo
-      - Nana-EC
       - stoqnkpL
       - stoyanov-st
-      - lukelee-sl
   - name: hcn-smart-contract-codeowners
     maintainers:
       - Ferparishuertas
     members:
       - lukelee-sl
+      - david-bakin-sl
       - bubo
+      - stoqnkpL
       - stoyanov-st
   - name: hcn-tools-and-libs-maintainers
     maintainers:


### PR DESCRIPTION
**Description**:

A reorder of maintainers, owners, commiters, to match the existing teams, and roles

- i added the nowdays maintainers to maintainers
- Moved the ones that are not maintaining only to commiter
- Kept only 1 maintainer matching the iniatiave lead


