### PR TITLE
Remove user with no verified email

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,7 +54,6 @@ teams:
       - atul-hedera
       - atulmahamuni
       - bguiz
-      - bibitibooo1
       - david-bakin-sl
       - devmab
       - dikel


### PR DESCRIPTION
`bibitibooo1` does not have a verified email and adding them causes errors in CLOWarden