### PR TITLE
Add nirbosl to hiero-mirror-node-committers members

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -160,6 +160,7 @@ teams:
       - nickeynikolovv
       - sdimitrov9
       - filev94
+      - nirbosl
   - name: hiero-mirror-node-maintainers
     maintainers:
       - steven-sheehy


### PR DESCRIPTION
**Description**:
This PR is adding Nir Ben-Or's user (`nirbosl`) to the `hiero-mirror-node-committers` members list.
It is meant to grant my user a higher permission level to the `hiero-ledger/hiero-mirror-node` repository in order to be able to link my issues from the DevOps `hashgraph/infrastructure` repository kanban board to mirrornode's as I work on mirrornode related tasks.

- Add `nirbosl` to the `hiero-mirror-node-committers` member list

**Related issue(s)**:
N/A

**Notes for reviewer**:
N/A

**Checklist**
N/A
