### PR TITLE
chore: Update config.yaml to change team names for hiero-consensus-node

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -359,7 +359,9 @@ teams:
       - Ferparishuertas
       - artemananiev
       - OlegMazurov
-  - name: hcn-release-managers
+      - rbarker-dev
+      - nathanklick
+  - name: hiero-consensus-node-release-managers
     maintainers:
       - rbarker-dev
       - nathanklick
@@ -379,7 +381,7 @@ teams:
       - Mark-Swirlds
       - ty-swirldslabs
       - Reccetech
-  - name: hcn-release-engineers
+  - name: hiero-consensus-node-release-engineers
     maintainers:
       - rbarker-dev
       - nathanklick
@@ -392,7 +394,7 @@ teams:
       - mhess-swl
       - iwsimon
       - thomas-swirlds-labs
-  - name: hcn-devops-codeowners
+  - name: hiero-consensus-node-devops-codeowners
     maintainers:
       - dalvizu
     members:
@@ -405,13 +407,13 @@ teams:
       - kfbr
       - shezaan-hashgraph
       - allison-hashgraph
-  - name: hcn-execution-maintainers
+  - name: hiero-consensus-node-execution-maintainers
     maintainers:
       - netopyr
     members:
       - Neeharika-Sompalli
       - tinker-michaelj
-  - name: hcn-execution-committers
+  - name: hiero-consensus-node-execution-committers
     maintainers:
       - Neeharika-Sompalli
       - netopyr
@@ -431,7 +433,7 @@ teams:
       - thomas-swirlds-labs
       - vtronkov
       - jsync-swirlds
-  - name: hcn-execution-codeowners
+  - name: hiero-consensus-node-execution-codeowners
     maintainers:
       - netopyr
     members:
@@ -450,7 +452,7 @@ teams:
       - povolev15
       - thomas-swirlds-labs
       - vtronkov
-  - name: hcn-execution-internal-contributors
+  - name: hiero-consensus-node-execution-internal-contributors
     maintainers:
       - netopyr
     members:
@@ -458,13 +460,13 @@ teams:
       - elpinkypie
       - joshmarinacci
       - gkozyryatskyy
-  - name: hcn-consensus-maintainers
+  - name: hiero-consensus-node-consensus-maintainers
     maintainers:
       - poulok
     members:
       - lpetrovic05
       - cody-littley
-  - name: hcn-consensus-committers
+  - name: hiero-consensus-node-consensus-committers
     maintainers:
       - poulok
     members:
@@ -476,7 +478,7 @@ teams:
       - mustafauzunn
       - IvanKavaldzhiev
       - abies
-  - name: hcn-consensus-codeowners
+  - name: hiero-consensus-node-consensus-codeowners
     maintainers:
       - poulok
     members:
@@ -490,7 +492,7 @@ teams:
       - mustafauzunn
       - IvanKavaldzhiev
       - abies
-  - name: hcn-smart-contract-maintainers
+  - name: hiero-consensus-node-smart-contract-maintainers
     maintainers:
       - Nana-EC
       - Ferparishuertas
@@ -498,7 +500,7 @@ teams:
       - lukelee-sl
       - bubo
       - stoyanov-st
-  - name: hcn-smart-contract-committers
+  - name: hiero-consensus-node-smart-contract-committers
     maintainers:
       - Nana-EC
       - Ferparishuertas
@@ -507,7 +509,7 @@ teams:
       - bubo
       - stoqnkpL
       - stoyanov-st
-  - name: hcn-smart-contract-codeowners
+  - name: hiero-consensus-node-smart-contract-codeowners
     maintainers:
       - Ferparishuertas
       - Nana-EC
@@ -515,12 +517,12 @@ teams:
       - lukelee-sl
       - stoyanov-st
       - bubo
-  - name: hcn-tools-and-libs-maintainers
+  - name: hiero-consensus-node-tools-and-libs-maintainers
     maintainers:
       - artemananiev
     members:
       - OlegMazurov
-  - name: hcn-tools-and-libs-committers
+  - name: hiero-consensus-node-tools-and-libs-committers
     maintainers:
       - artemananiev
     members:
@@ -528,7 +530,7 @@ teams:
       - thenswan
       - anthony-swirldslabs
       - Jeffrey-morgan34
-  - name: hcn-tools-and-libs-codeowners
+  - name: hiero-consensus-node-tools-and-libs-codeowners
     maintainers:
       - artemananiev
     members:
@@ -927,22 +929,22 @@ repositories:
       hiero-automation: write
       github-maintainers: maintain
       hiero-consensus-node-maintainers: maintain
-      hcn-release-managers: write
-      hcn-release-engineers: write
-      hcn-devops-codeowners: write
-      hcn-execution-maintainers: maintain
-      hcn-execution-committers: write
-      hcn-execution-codeowners: write
-      hcn-execution-internal-contributors: triage
-      hcn-consensus-maintainers: maintain
-      hcn-consensus-committers: write
-      hcn-consensus-codeowners: write
-      hcn-smart-contract-maintainers: maintain
-      hcn-smart-contract-committers: write
-      hcn-smart-contract-codeowners: write
-      hcn-tools-and-libs-maintainers: maintain
-      hcn-tools-and-libs-committers: write
-      hcn-tools-and-libs-codeowners: write
+      hiero-consensus-node-release-managers: write
+      hiero-consensus-node-release-engineers: write
+      hiero-consensus-node-devops-codeowners: write
+      hiero-consensus-node-execution-maintainers: maintain
+      hiero-consensus-node-execution-committers: write
+      hiero-consensus-node-execution-codeowners: write
+      hiero-consensus-node-execution-internal-contributors: triage
+      hiero-consensus-node-consensus-maintainers: maintain
+      hiero-consensus-node-consensus-committers: write
+      hiero-consensus-node-consensus-codeowners: write
+      hiero-consensus-node-smart-contract-maintainers: maintain
+      hiero-consensus-node-smart-contract-committers: write
+      hiero-consensus-node-smart-contract-codeowners: write
+      hiero-consensus-node-tools-and-libs-maintainers: maintain
+      hiero-consensus-node-tools-and-libs-committers: write
+      hiero-consensus-node-tools-and-libs-codeowners: write
       hiero-mirror-node-maintainers: write
       hiero-gradle-conventions-maintainers: write
       hiero-performance-engineers: write


### PR DESCRIPTION
Hiero-consensus-node team names have been truncated such that they are `hcn-<team-name>`. This has the potential to cause confusion.

Per the community call on 2025-04-03 the `hcn-**` teams should have names updated to reflect the repository they are contained within: `hiero-consensus-node-**`.

This PR aims to do that.
