### PR TITLE
Add netopyr as a consensus module committer and code owner

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -478,6 +478,7 @@ teams:
       - mustafauzunn
       - IvanKavaldzhiev
       - abies
+      - netopyr
   - name: hiero-consensus-node-consensus-codeowners
     maintainers:
       - poulok
@@ -492,6 +493,7 @@ teams:
       - mustafauzunn
       - IvanKavaldzhiev
       - abies
+      - netopyr
   - name: hiero-consensus-node-consensus-internal-contributors
     maintainers:
       - poulok


### PR DESCRIPTION
**Description**:
Please vote on this proposal to make `netopyr` a committer and code owner of the consensus module.