### PR TITLE
Chore: Remove community group from config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,116 +16,6 @@ teams:
       - andrewb1269hg
       - leninmehedy
       - PavelSBorisov
-  - name: community
-    maintainers:
-      - hendrikebbers
-    members:
-      - Ferparishuertas
-      - nadineloepfe
-      - samswag
-      - AliNik4n
-      - Ashe-Oro
-      - BartoszSolkaArianelabs
-      - Coiling-Dragon
-      - Daniel-K-Ivanov
-      - defigirlxo
-      - Kirqkas
-      - LionelChocron
-      - Mark-Swirlds
-      - Neurone
-      - Petyo-Lukanov
-      - RAMTO
-      - RaphaelMessian
-      - Reccetech
-      - Sheng-Long
-      - StanislawMazowieckiAriane
-      - StoyanDrumev
-      - SvetBorislavov
-      - VMN00B
-      - acuarica
-      - amckay7777
-      - annamariyaivanova
-      - anthony-swirldslabs
-      - ar-conmit
-      - arianejasuwienas
-      - arlanharris
-      - arrusev
-      - artemananiev
-      - atul-hedera
-      - atulmahamuni
-      - bguiz
-      - david-bakin-sl
-      - devmab
-      - dikel
-      - dimitar-dinev
-      - diptimahamuni
-      - dmueller2001
-      - donaldthibeau
-      - dougvk
-      - dr20240304
-      - ebadiere
-      - ed-marquez
-      - edward-swirldslabs
-      - ericleponner
-      - failfmi
-      - fakepaulbugeja
-      - gregscullard
-      - imalygin
-      - instamenta
-      - isaac-swirldslabs
-      - janaakhterov
-      - jasperpotts
-      - jayv80
-      - jbair06
-      - jeromy-cannon
-      - joan41868
-      - joebxmoxx
-      - justin-atwell
-      - kacper-koza-arianelabs
-      - kenthejr
-      - kfa-aguda
-      - litt3
-      - lpetrovic05
-      - lukelee-sl
-      - m-swirldslabs
-      - maptuhec
-      - matteriben
-      - mb-swirlds
-      - mgarbs
-      - michalrozekariane
-      - michielmulders
-      - mmalik-al
-      - nadezhdapopovaa
-      - nistanimirov
-      - norbert-kulus-arianelabs
-      - ochikov
-      - ohsnapandrew
-      - olsentorfinn
-      - pathornteng
-      - pjn82
-      - pkaterskiLime
-      - quiet-node
-      - reachtobhavesh
-      - rickyrodmac
-      - rsinha
-      - rustyShacklefurd
-      - ryan-swirldslabs
-      - se7enarianelabs
-      - sergmetelin
-      - stoyan-lime
-      - stoyanov-st
-      - svetoslav-nikol0v
-      - svienot
-      - tdermendzhievv
-      - theekrystallee
-      - thenswan
-      - tim-mchale
-      - tolorukooba
-      - travismccracken11
-      - ty-swirldslabs
-      - web3-nomad
-      - yiliev0
-      - yosiftouma
   - name: tsc
     maintainers:
       - hendrikebbers
@@ -782,7 +672,6 @@ repositories:
     visibility: public
   - name: hiero-website
     teams:
-      community: triage
       tsc: maintain
       github-maintainers: maintain
       security-maintainers: triage
@@ -807,7 +696,6 @@ repositories:
     visibility: public
   - name: awesome-contributions
     teams:
-      community: triage
       github-maintainers: maintain
       security-maintainers: triage
       prod-security: triage


### PR DESCRIPTION
Due to lack of response to invitations, we need to remove this group. Triage of the hiero-website and awesome-contributions repo will be done by other assigned teams.

The community is always welcomed to participate by contribuiting to any repo via PR.

