### PR TITLE
chore: propose gsstoykov Rust SDK maintainer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -110,6 +110,7 @@ teams:
     maintainers:
       - RickyLB
       - Sheng-Long
+      - gsstoykov
     members:
       - SimiHunjan
   - name: hiero-sdk-rust-committers


### PR DESCRIPTION
**Description**:
This PR adds gsstoykov as a Rust SDK maintainer
