### PR TITLE
chore: Update config.yaml to add solo-admins team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -660,6 +660,12 @@ teams:
       - venilinvasilev
       - naydenovn
     members: []
+  - name: solo-admins
+    maintainers:
+      - nathanklick
+    members:
+      - jeromy-cannon
+      - leninmehedy
   - name: solo-maintainers
     maintainers:
       - nathanklick
@@ -962,6 +968,7 @@ repositories:
       tsc: maintain
       hiero-automation: write
       github-maintainers: maintain
+      solo-admins: admin
       solo-maintainers: maintain
       solo-committers: write
       security-maintainers: triage


### PR DESCRIPTION
## Description

Adds the `solo-admins` team

See [RESD-225](https://swirldslabs.atlassian.net/servicedesk/customer/portal/7/RESD-225)

### Related Issue(s)

closes #223
