### PR TITLE
chore: Move Tim Farber-Newman

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -323,6 +323,7 @@ teams:
       - thomas-swirlds-labs
       - vtronkov
       - jsync-swirlds
+      - timfn-hg
   - name: hiero-consensus-node-execution-codeowners
     maintainers:
       - netopyr
@@ -342,6 +343,7 @@ teams:
       - povolev15
       - thomas-swirlds-labs
       - vtronkov
+      - timfn-hg
   - name: hiero-consensus-node-execution-internal-contributors
     maintainers:
       - netopyr
@@ -364,7 +366,6 @@ teams:
       - litt3
       - mxtartaglia-sl
       - timo0
-      - timfn-hg
       - mustafauzunn
       - IvanKavaldzhiev
       - abies
@@ -379,7 +380,6 @@ teams:
       - litt3
       - mxtartaglia-sl
       - timo0
-      - timfn-hg
       - mustafauzunn
       - IvanKavaldzhiev
       - abies


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds `timfn-hg` to the `hiero-consensus-node-execution-committers`, `hiero-consensus-node-execution-codeowners` teams which grants access to the `hiero-consensus-node-execution` project.
- Removes `timfn-hg` from the `hiero-consensus-node-consensus-committers, `hiero-consensus-node-consensus-codeowners` teams which revokes access to the `hiero-consensus-node-consensus` project.

### Related Issue(s)

- closes #153

## Voting

### Voting is required

Per the guidelines outlined in the `roles-and-groups.md` in this repository votes should be cast as follows:

- Vote <span style="color:green">**in favor**</span> of the candidate's promotion by **approving** the PR with a **comment indicating approval**.
- Vote <span style="color:red">**against**</span> the candidate's promotion by **posting a comment in the PR along with their explanation**.
- Vote <span style="color:orange">**to abstain**</span> by **posting a comment in the PR along with their explanation**.

### Voting Period

The vote will close on `<Wednesday, May 21, 2025>` at `<16:00:00>` UTC.