### PR TITLE
chore: Update config.yaml to add maintainers groups to governance (triage)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -709,6 +709,27 @@ repositories:
       security-maintainers: write
       prod-security: write
       sec-ops: write
+      hiero-block-node-maintainers: triage
+      hiero-consensus-node-maintainers: triage
+      hiero-docs-maintainers: triage
+      hiero-gradle-conventions-maintainers: triage
+      hiero-improvement-proposals-maintainers: triage
+      hiero-json-rpc-relay-maintainers: triage
+      hiero-local-node-maintainers: triage
+      hiero-mirror-node-maintainers: triage
+      hiero-mirror-node-explorer-maintainers: triage
+      hiero-protobufs-maintainers: triage
+      hiero-sdk-cpp-maintainers: triage
+      hiero-sdk-go-maintainers: triage
+      hiero-sdk-java-maintainers: triage
+      hiero-sdk-js-maintainers: triage
+      hiero-sdk-python-maintainers: triage
+      hiero-sdk-rust-maintainers: triage
+      hiero-sdk-swift-maintainers: triage
+      hiero-sdk-tck-maintainers: triage
+      hiero-solo-action-maintainers: triage
+      sdk-collaboration-hub-maintainers: triage
+      solo-maintainers: triage
     visibility: public
   - name: hiero-website
     teams:

--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,62 @@ teams:
       - hartm
       - minyu66
       - thelinuxfoundation
+  - name: governance-triage
+    maintainers:
+      - ryjones
+      - jwagantall
+      - hendrikebbers
+      - rbarker-dev
+      - nathanklick
+      - andrewb1269hg
+    members:
+      - 0xivanov
+      - AlfredoG87
+      - AlexanderShenshin
+      - Ferparishuertas
+      - Neeharika-Sompalli
+      - Nana-EC
+      - OlegMazurov
+      - PavelSBorisov
+      - RaphaelMessian
+      - Reccetech
+      - RickyLB
+      - Sheng-Long
+      - SimiHunjan
+      - acuarica
+      - agadzhalov
+      - artemananiev
+      - cody-littley
+      - deshmukhpranali
+      - dmueller2001
+      - ericleponner
+      - georgi-l95
+      - gsstoykov
+      - ivaylogarnev-limechain
+      - ivaylonikolov7
+      - jasperpotts
+      - jeromy-cannon
+      - jjohannes
+      - konstantinabl
+      - leninmehedy
+      - lpetrovic05
+      - lukelee-sl
+      - mattp-swirldslabs
+      - mgarbs
+      - nadineloepfe
+      - natanasow
+      - netopyr
+      - poulok
+      - quiet-node
+      - rbair23
+      - rwalworth
+      - sergmetelin
+      - simzzz
+      - steven-sheehy
+      - svienot
+      - theekrystallee
+      - tinker-michaelj
+      - xin-hedera
   - name: hiero-mirror-node-committers
     maintainers:
       - steven-sheehy
@@ -709,27 +765,7 @@ repositories:
       security-maintainers: write
       prod-security: write
       sec-ops: write
-      hiero-block-node-maintainers: triage
-      hiero-consensus-node-maintainers: triage
-      hiero-docs-maintainers: triage
-      hiero-gradle-conventions-maintainers: triage
-      hiero-improvement-proposals-maintainers: triage
-      hiero-json-rpc-relay-maintainers: triage
-      hiero-local-node-maintainers: triage
-      hiero-mirror-node-maintainers: triage
-      hiero-mirror-node-explorer-maintainers: triage
-      hiero-protobufs-maintainers: triage
-      hiero-sdk-cpp-maintainers: triage
-      hiero-sdk-go-maintainers: triage
-      hiero-sdk-java-maintainers: triage
-      hiero-sdk-js-maintainers: triage
-      hiero-sdk-python-maintainers: triage
-      hiero-sdk-rust-maintainers: triage
-      hiero-sdk-swift-maintainers: triage
-      hiero-sdk-tck-maintainers: triage
-      hiero-solo-action-maintainers: triage
-      sdk-collaboration-hub-maintainers: triage
-      solo-maintainers: triage
+      governance-triage: triage
     visibility: public
   - name: hiero-website
     teams:


### PR DESCRIPTION
## Description

Add maintainer groups to the governance repo with `triage` permissions so that maintainers can create PRs with labels & request reviews on those PRs.

