### PR TITLE
Add lukasz-hashgraph as internal contributor

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -360,6 +360,7 @@ teams:
       - elpinkypie
       - gkozyryatskyy
       - joshmarinacci
+      - lukasz-hashgraph
   - name: hiero-consensus-node-release-managers
     maintainers:
       - rbarker-dev


### PR DESCRIPTION
 The PR adds  lukasz-hashgraph in hiero-smart-contracts-internal-contributors