### PR TITLE
Add jsync-swirlds to Block Node maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -275,6 +275,7 @@ teams:
     members:
       - AlfredoG87
       - jasperpotts
+      - jsync-swirlds
       - mattp-swirldslabs
   - name: hiero-block-node-committers
     maintainers:


### PR DESCRIPTION
**Description**:

Based on continuous contributions in both design, code, technical awareness of the product, issue and roadmap management I think `jsync-swirlds` has earned a spot in the Block Node maintainers group and nominate him for a bump up from committer to maintainer status.

- Add `jsync-swirlds` to `hiero-block-node-maintainers`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
