### PR TITLE
chore: Remove Ed, Mustafa, and Ivan K from consensus module code owners

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -432,12 +432,9 @@ teams:
       - poulok
     members:
       - lpetrovic05
-      - edward-swirldslabs
       - litt3
       - mxtartaglia-sl
       - timo0
-      - mustafauzunn
-      - IvanKavaldzhiev
       - abies
       - netopyr
   - name: hiero-consensus-node-smart-contract-codeowners


### PR DESCRIPTION
**Description**:
Removes the following people from the `hiero-consensus-node-consensus-codeowners` group per their request:
- @mustafauzunn
- @IvanKavaldzhiev
- @edward-swirldslabs 

### Voting
**Voting is required**
Per the guidelines outlined in the roles-and-groups.md in this repository votes should be cast as follows:
• Vote in favor of the candidate's promotion by approving the PR with a comment indicating approval.
• Vote against the candidate's promotion by posting a comment in the PR along with their explanation.
• Vote to abstain by posting a comment in the PR along with their explanation.

**Voting Period**
The vote will close on Wednesday 16th July at 23:59:00 CEST