### PR TITLE
Nominating exploreriii as python sdk maintainer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -144,13 +144,13 @@ teams:
     maintainers:
       - nadineloepfe
     members:
-      - hendrikebbers
       - rbair23
+      - exploreriii
   - name: hiero-sdk-python-committers
     maintainers:
       - nadineloepfe
     members:
-      - exploreriii
+      - hendrikebbers
       - Dosik13
   - name: hiero-did-sdk-js-maintainers
     maintainers:


### PR DESCRIPTION
Nominating `exploreriii` as python sdk maintainer
Moving `hendrikebbers` from maintainer to committers

@nadineloepfe @rbair23 can you please approve?