### PR TITLE
chore: add a new homebrew-solo repository for the Solo project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1051,6 +1051,18 @@ repositories:
       prod-security: triage
       sec-ops: triage
     visibility: public
+  - name: homebrew-solo
+    teams:
+      tsc: maintain
+      hiero-automation: write
+      github-maintainers: maintain
+      solo-admins: admin
+      solo-maintainers: maintain
+      solo-committers: write
+      security-maintainers: triage
+      prod-security: triage
+      sec-ops: triage
+    visibility: public
   - name: tsc-eligibility-check
     teams:
       tsc: maintain


### PR DESCRIPTION
## Description

This pull request adds a new repository configuration to the `config.yaml` file. The update introduces the `homebrew-solo` repository and assigns appropriate team permissions.

Repository configuration changes:

* Added the `homebrew-solo` repository with specified team permissions and set its visibility to public.

## Justification

This repository is needed to support [Homebrew Taps](https://docs.brew.sh/Taps) for the Solo project. This repository is a hard requirement from Homebrew in order to support the `brew tap hiero-ledger/solo` syntax. Please see the documentation snippet below.

<img width="626" height="207" alt="image" src="https://github.com/user-attachments/assets/88121e3f-4aba-485d-90d8-4d8718c5bc44" />

- required by: https://github.com/hiero-ledger/solo/issues/1001

