### PR TITLE
chore: Rename governance-triage to governance-write

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,7 @@ teams:
       - hartm
       - minyu66
       - thelinuxfoundation
-  - name: governance-triage
+  - name: governance-write
     maintainers:
       - ryjones
       - jwagantall
@@ -764,7 +764,7 @@ repositories:
       security-maintainers: write
       prod-security: write
       sec-ops: write
-      governance-triage: triage
+      governance-write: write
     visibility: public
   - name: hiero-website
     teams:


### PR DESCRIPTION
**Description**:

Switch the permissions on governance-triage team to be `write` instead of triage. Update the name to reflect the change.

This group needs to be able to create issues, branches, and push to the repo without forking it.
