### PR TITLE
Update BN committers (add mustafauzunn) and maintainers (remove mattp-swirldslabs)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -303,22 +303,22 @@ teams:
       - AlfredoG87
       - jasperpotts
       - jsync-swirlds
-      - mattp-swirldslabs
   - name: hiero-block-node-committers
     maintainers:
       - AlfredoG87
       - Nana-EC
     members:
-      - rbarker-dev
-      - georgi-l95
       - ata-nas
-      - jasperpotts
-      - jsync-swirlds
-      - san-est
-      - rbair23
       - a-saksena
       - CMiville42
+      - georgi-l95
+      - jasperpotts
+      - jsync-swirlds
       - mattp-swirldslabs
+      - mustafauzunn
+      - rbair23
+      - rbarker-dev
+      - san-est
   - name: hiero-consensus-node-maintainers
     maintainers:
       - Nana-EC


### PR DESCRIPTION
**Description**:
This pull request changes the following:

- Adds `mustafauzunn` to the `hiero-block-node-committers` team which grants access to the [Block Node Repo](https://github.com/hiero-ledger/hiero-block-node) project and write access to the repository.
- Removes `mattp-swirldslabs` from the `hiero-block-node-maintainers` team which governs maintainer role for the [Block Node Repo](https://github.com/hiero-ledger/hiero-block-node).

**Related issue(s)**:

Fixes #374 

## Voting

### Voting is required

Per the guidelines outlined in the `roles-and-groups.md` in this repository votes should be cast as follows:

- Vote <span style="color:green">**in favor**</span> of the candidate's promotion by **approving** the PR with a **comment indicating approval**.
- Vote <span style="color:red">**against**</span> the candidate's promotion by **posting a comment in the PR along with their explanation**.
- Vote <span style="color:orange">**to abstain**</span> by **posting a comment in the PR along with their explanation**.

### Voting Period

The vote will close on `Friday, August 27, 2025)` at `21:00:00` UTC.

**Notes for reviewer**:
Based on continuous contributions I think `mustafauzunn` has earned a spot in the Block Node committers group.
Similarly in line with Hiero open source contributions expectations it no longer seems appropriate to keep `mattp-swirldslabs` in the maintainers list as it has impacts on PR review velocity and adds overhead to continuously reassign auto assignments 