### PR TITLE
Update config.yaml to add Reccetech as a committer to hiero improveme…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -606,6 +606,7 @@ teams:
       - sergmetelin
       - mgarbs
       - RaphaelMessian
+      - Reccetech
     members:
       - swirlds-automation
       - kenthejr


### PR DESCRIPTION
This PR nominates Reccetech as a committer for the Hiero Improvement Proposals (HIP) project.
Reccetech has demonstrated consistent and valuable contributions to the HIP process. One example is https://github.com/hiero-ledger/hiero-improvement-proposals/pull/762 and there are several others.
As per the governance guidelines, this nomination recognizes their:

Active engagement with the HIP community
Quality contributions and reviews
Understanding of the project's goals and processes

This change adds Reccetech's GitHub account to the committers list in config.yaml.
Voting: This PR requires approval from project maintainers as outlined in the [governance voting guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#voting).