### PR TITLE
feat: add homebrew tools repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -699,6 +699,21 @@ teams:
       - hendrikebbers
     members:
       - exploreriii
+  - name: homebrew-tools-maintainers
+    maintainers:
+      - rbarker-dev
+      - andrewb1269hg
+      - nathanklick
+    members:
+      - jeromy-cannon
+  - name: homebrew-tools-committers
+    maintainers:
+      - rbarker-dev
+      - andrewb1269hg
+      - nathanklick
+    members:
+      - hendrikebbers
+      - michielmulders
   - name: security-maintainers
     maintainers:
       - nathanklick
@@ -1068,6 +1083,16 @@ repositories:
       github-maintainers: maintain
       hiero-improvement-proposals-maintainers: maintain
       hiero-improvement-proposals-committers: write
+      security-maintainers: triage
+      prod-security: triage
+      sec-ops: triage
+    visibility: public
+  - name: homebrew-tools
+    teams:
+      tsc: maintain
+      github-maintainers: maintain
+      homebrew-tools-maintainers: maintain
+      homebrew-tools-committers: write
       security-maintainers: triage
       prod-security: triage
       sec-ops: triage


### PR DESCRIPTION
## Description

This pull request updates the `config.yaml` file to add new teams and repository access rules for the `homebrew-tools` project. The main changes are the creation of dedicated teams for maintainers and committers, and the configuration of their permissions on the new `homebrew-tools` repository.

**Team management:**

* Added two new teams: `homebrew-tools-maintainers` and `homebrew-tools-committers`, each with designated maintainers and members.

**Repository access configuration:**

* Registered the new `homebrew-tools` repository and assigned the appropriate permissions to the newly created teams, as well as to existing teams.

### Related Issues

- hiero-ledger/tsc#228

## Approvals Required

This pull request requires approval from the TSC for the formation of the project requested in hiero-ledger/tsc#228 issue.