### PR TITLE
chore: add devmab to hiero-cli-committers group

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -523,6 +523,7 @@ teams:
     maintainers:
       - michielmulders
     members:
+      - devmab
       - misiekp
       - michalrozekariane
       - mateuszm-arianelabs


### PR DESCRIPTION
**Description**:

Add `devmab` to `hiero-cli-committers` group.

**Related Issue(s)**:

Implements #397
