### PR TITLE
Propose adding `akdev` to list of committers for consensus-node repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -347,6 +347,7 @@ teams:
       - poulok
     members:
       - abies
+      - akdev
       - anastasiya-kovaliova
       - anthony-swirldslabs
       - artemananiev


### PR DESCRIPTION
Propose Akram (`akdev`) to the list of committers to the consensus-node repo, since he has been participating in code reviews, design discussions and creating issues for the execution team.