### PR TITLE
chore(vote): Add Jeffrey as a committer to homebrew tools

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -714,6 +714,7 @@ teams:
       - nathanklick
     members:
       - hendrikebbers
+      - JeffreyDallas
       - michielmulders
   - name: security-maintainers
     maintainers:


### PR DESCRIPTION
This pull request makes a minor update to the team membership configuration by adding a new member to an existing team. 

* Added `JeffreyDallas` to the list of members in the `teams` section of `config.yaml` for `homebrew-tools-committers`.

This is a voting PR.

Approvals needed by the maintainer group for homebrew tools.
@nathanklick ✅ 
@rbarker-dev ✅ 
@andrewb1269hg ✅ 
@jeromy-cannon 

Voting should complete by 2025-10-07