### PR TITLE
Add Reccetech to members in docs-maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -547,6 +547,7 @@ teams:
       - theekrystallee
     members:
       - deshmukhpranali
+      - Reccetech
   - name: hiero-docs-committers
     maintainers:
       - SimiHunjan


### PR DESCRIPTION
This request is so that we are able to provide Hiero Docs Gitbooks backend access as well.
Fix: https://github.com/hiero-ledger/governance/issues/404