### PR TITLE
Add joshmarinacci to Consensus Node Teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -363,6 +363,7 @@ teams:
       - iwsimon
       - Jeffrey-morgan34
       - JivkoKelchev
+      - joshmarinacci
       - jsync-swirlds
       - kimbor
       - litt3
@@ -454,6 +455,7 @@ teams:
       - ibankov
       - iwsimon
       - JivkoKelchev
+      - joshmarinacci
       - kimbor
       - mhess-swl
       - MiroslavGatsanoga


### PR DESCRIPTION
**Description**:
@joshmarinacci has been part of the Execution team since March 2025. He has been making significant contributions to the `hiero-consensus-node` repo and he is currently the lead engineer on the Simple Fees project [HIP-1261](https://hips.hedera.com/hip/hip-1261). Please vote to add him to the `hiero-consensus-node-committers`, `hiero-consensus-node-execution-codeowners` teams as a member.