### PR TITLE
chore: Remove 'renbtg' from maintainers list

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -395,7 +395,6 @@ teams:
       - AlexKehayov
       - a-saksena
       - joshmarinacci
-      - renbtg
   - name: hiero-consensus-node-release-managers
     maintainers:
       - rbarker-dev


### PR DESCRIPTION
This pull request makes a minor update to the `config.yaml` file, removing the user `renbtg` from the list of maintainers for a team.

- Removed `renbtg` from the maintainers list in the `teams` section of `config.yaml`.