### PR TITLE
chore: add manishdait as a committer to the python sdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -153,6 +153,7 @@ teams:
     members:
       - hendrikebbers
       - Dosik13
+      - manishdait
   - name: hiero-did-sdk-js-maintainers
     maintainers:
       - AlexanderShenshin


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds `manishdait` to the `hiero-sdk-python-committers` team(s) which grants access to the
  `hiero-sdk-python` project(s) and `write` access to the repository.

### Related Issue(s)

https://github.com/hiero-ledger/governance/issues/419

## Voting

### Voting is required

Per the guidelines outlined in the `roles-and-groups.md` in this repository votes should be cast as follows:

- Vote <span style="color:green">**in favor**</span> of the candidate's promotion by **approving** the PR with a **comment indicating approval**.
- Vote <span style="color:red">**against**</span> the candidate's promotion by **posting a comment in the PR along with their explanation**.
- Vote <span style="color:orange">**to abstain**</span> by **posting a comment in the PR along with their explanation**.

### Voting Period

The vote will close on `<11 07, 2025>(Friday, November 7, 2025)` 