### PR TITLE
Replace Paulo Caldas GH account in Hiero DID SDK Python team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -178,7 +178,7 @@ teams:
     maintainers:
       - Reccetech
     members:
-      - paulo-caldas-code
+      - paulo-caldas
   - name: hiero-sdk-rust-maintainers
     maintainers:
       - RickyLB


### PR DESCRIPTION
**Description**:
This PR replaces Paulo Caldas GH account from @paulo-caldas-code to @paulo-caldas in Hiero DID SDK Python committers team.

The change was requested by Paulo as he's planning to "merge" these two and continue to use @paulo-caldas.