### PR TITLE
Add new Hiero CLI committers to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -536,11 +536,12 @@ teams:
     maintainers:
       - michielmulders
     members:
+      - devmab
       - piotrswierzy
-      - michalprzybyla
-      - michalrozek90
-      - mateusz-marcin
-      - se7enarianelabs
+      - misiek-blocky
+      - matevszm
+      - rozekmichal
+      - mmyslblocky
   - name: hiero-docs-maintainers
     maintainers:
       - SimiHunjan


### PR DESCRIPTION
The Ariane Labs team has changed from public to private accounts.
Old accounts have been removed except one user.