### PR TITLE
hiero-enterprise-java added

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -831,6 +831,16 @@ teams:
     maintainers:
       - kantorcodes
     members: []
+  - name: hiero-enterprise-java-maintainers
+    maintainers:
+      - hendrikebbers
+    members: []
+  - name: hiero-enterprise-java-committers
+    maintainers:
+      - Ndacyayisenga-droid
+    members:
+      - manishdait
+      - sebtiem
 repositories:
   - name: governance
     teams:
@@ -1141,6 +1151,16 @@ repositories:
       github-maintainers: maintain
       homebrew-tools-maintainers: maintain
       homebrew-tools-committers: write
+      security-maintainers: triage
+      prod-security: triage
+      sec-ops: triage
+    visibility: public
+  - name: hiero-enterprise-java
+    teams:
+      tsc: maintain
+      github-maintainers: maintain
+      hiero-enterprise-java-maintainers: maintain
+      hiero-enterprise-java-committers: write
       security-maintainers: triage
       prod-security: triage
       sec-ops: triage


### PR DESCRIPTION
This pull request updates the `config.yaml` file to add new teams and configure repository permissions for the `hiero-enterprise-java` repository. The main changes include the creation of two new teams for maintainers and committers, and the assignment of appropriate permissions to these teams for the new repository.