### PR TITLE
Add solo-internal-contributors team for solo repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -805,6 +805,17 @@ teams:
       - Ivo-Yankov
       - instamenta
       - alex-kuzmin-hg
+  - name: solo-internal-contributors
+    maintainers:
+      - nathanklick
+      - jeromy-cannon
+      - leninmehedy
+    members:
+      - olsentorfinn
+      - JeffreyDallas
+      - Ivo-Yankov
+      - instamenta
+      - alex-kuzmin-hg
   - name: tsc-eligibility-check-admins
     maintainers:
       - jwagantall
@@ -1165,6 +1176,7 @@ repositories:
       solo-admins: admin
       solo-maintainers: maintain
       solo-committers: write
+      solo-internal-contributors: triage
       security-maintainers: triage
       prod-security: triage
       sec-ops: triage


### PR DESCRIPTION
Adds solo-internal-contributors team with maintainers and members

Grants triage access for solo-internal-contributors on solo repo

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
