### PR TITLE
Add new members to hiero-cli-committers in config.yaml (#436)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -536,6 +536,8 @@ teams:
       - michielmulders
     members:
       - Neurone
+      - piotrswierzy
+      - devmab
   - name: hiero-cli-committers
     maintainers:
       - michielmulders


### PR DESCRIPTION
**Description**:
Adds hiero-cli contributors to `hiero-cli-maintainers`, so that they can review and merge PRs.



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
