### PR TITLE
Add Toktar as committer to Identity Collaboration Hub

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -627,6 +627,7 @@ teams:
       - AlexanderShenshin
     members:
       - ChangoBuitrago
+      - Toktar
   - name: hiero-improvement-proposals-maintainers
     maintainers:
       - sergmetelin


### PR DESCRIPTION
I'd like to request adding @Toktar from DSR team to Hiero Identity Collaboration Hub committers group (`identity-collaboration-hub-committers`), so she'll have write access to the repo.
