### PR TITLE
feat: new triage role members python sdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -167,6 +167,9 @@ teams:
       - MonaaEid
       - AntonioCeppellini
       - Adityarya11
+      - aceppaluni
+      - emiliyank
+      - Akshat8510
   - name: hiero-did-sdk-js-maintainers
     maintainers:
       - AlexanderShenshin


### PR DESCRIPTION
**Description**:
I would like to propose adding these new triage Junior Committers to the Python SDK

- [aceppaluni](https://github.com/aceppaluni)
- [emiliyank](https://github.com/emiliyank)
- [Akshat8510](https://github.com/Akshat8510)

In my opinion, they each would be a valuable addition to the Python SDK team!

Fixes #454

**Notes for reviewer**:
These developers have each made
- Valuable long-term contributions to code and the community
- Show interest in reviewing pull requests and building more skills
- Are motivated and interested in the project
