### PR TITLE
Add AlexanderShenshin as maintainer to Identity Collaboration Hub

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -643,6 +643,7 @@ teams:
     members:
       - Harasz
       - ChangoBuitrago
+      - AlexanderShenshin
   - name: identity-collaboration-hub-committers
     maintainers:
       - Reccetech


### PR DESCRIPTION
I'd like to vouch for maintaining Hiero Identity Collaboration Hub repo and get corresponding role.

Currently, I'm a core maintainer and author for Hiero decentralized identity (DID) SDKs and corresponding integration plugins for OWF projects (ACA-Py, Credo), so I'm planning to actively contribute and drive Hiero Identity Collaboration Hub development as well.

Please note that I already have a `committer` role in the repo, but I believe that `maintainer` role will make it more convenient for me to manage the repo. This is especially relevant since we're expecting significant contributions to the repo (identity tools & reference implementations).
