### PR TITLE
proposal: rename GFI commitee to support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,7 +99,7 @@ teams:
       - theekrystallee
       - tinker-michaelj
       - xin-hedera
-  - name: hiero-sdk-good-first-issue-support
+  - name: hiero-sdk-python-good-first-issue-support
     maintainers:
       - hendrikebbers
     members:
@@ -1119,7 +1119,7 @@ repositories:
       hiero-sdk-python-maintainers: maintain
       hiero-sdk-python-committers: write
       hiero-sdk-python-triage: triage
-      hiero-sdk-good-first-issue-support: triage
+      hiero-sdk-python-good-first-issue-support: triage
       security-maintainers: triage
       prod-security: triage
       sec-ops: triage


### PR DESCRIPTION
**Description**:
Renames GFI commitee to GFI support, because that is more closely aligned to what it does

Fixes #460 


