### PR TITLE
Rename `hiero-sdk-python-good-first-issue-support` to generic sdk name, and add to `hiero-sdk-cpp`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,7 +99,7 @@ teams:
       - theekrystallee
       - tinker-michaelj
       - xin-hedera
-  - name: hiero-sdk-python-good-first-issue-support
+  - name: hiero-sdk-good-first-issue-support
     maintainers:
       - hendrikebbers
     members:
@@ -1050,6 +1050,7 @@ repositories:
     teams:
       tsc: maintain
       github-maintainers: maintain
+      hiero-sdk-good-first-issue-support: triage
       hiero-sdk-cpp-maintainers: maintain
       hiero-sdk-cpp-committers: write
       security-maintainers: triage
@@ -1134,10 +1135,10 @@ repositories:
     teams:
       tsc: maintain
       github-maintainers: maintain
+      hiero-sdk-good-first-issue-support: triage
       hiero-sdk-python-maintainers: maintain
       hiero-sdk-python-committers: write
       hiero-sdk-python-triage: triage
-      hiero-sdk-python-good-first-issue-support: triage
       security-maintainers: triage
       prod-security: triage
       sec-ops: triage


### PR DESCRIPTION
This PR generalizes the name of the good first issue support group, as well as adds triage support for it to the C++ sdk.