### PR TITLE
Add Artem and Alex to `hiero-consensus-node-committers`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -381,6 +381,8 @@ teams:
       - poulok
     members:
       - abies
+      - aderevets
+      - AlexKehayov
       - akdev
       - anastasiya-kovaliova
       - anthony-swirldslabs


### PR DESCRIPTION
Proposing to add @aderevets and @AlexKehayov to `hiero-consensus-node-committers`. They have been part of the Execution team and have been making significant contributions. 
Please vote to add them to `hiero-consensus-node-committers`. Thanks!