### PR TITLE
Add ashumahajan to hiero-mirror-node-committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,6 +111,7 @@ teams:
       - steven-sheehy
       - xin-hedera
     members:
+      - ashumahajan
       - bilyana-gospodinova
       - IvanKavaldzhiev
       - jnels124


### PR DESCRIPTION
**Description**:

Propose to add `ashumahajan` to `hiero-mirror-node-committers`. He's been making contributions to mirror node for more than half a year including major functionality like HIP-1195 Hooks. Please vote for his addition.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
