### PR TITLE
chore: Added new account and removed old

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -806,7 +806,7 @@ teams:
       - dr20240304
       - reachtobhavesh
       - mody-hashgraph
-      - dpswirld
+      - diogper
   - name: sec-ops
     maintainers:
       - nathanklick


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds `diogper` to the `prod-security` team(s) and removed dpswirld.

