### PR TITLE
feat: Add java template repo for hiero-project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -345,8 +345,9 @@ teams:
     maintainers:
       - rbarker-dev
       - andrewb1269
+      - jjohannes
     members:
-      - san-est
+      - PavelSBorisov
   - name: hiero-block-node-maintainers
     maintainers:
       - Nana-EC
@@ -1109,6 +1110,15 @@ repositories:
       prod-security: triage
       sec-ops: triage
     visibility: public
+  - name: hiero-java-project-template
+    teams:
+      tsc: maintain
+      github-maintainers: maintain
+      hiero-gradle-conventions-maintainers: maintain
+      hiero-gradle-conventions-committers: write
+      security-maintainers: triage
+      prod-security: triage
+      sec-ops: triage
   - name: hiero-sdk-go
     teams:
       tsc: maintain


### PR DESCRIPTION
## Description

🔔  **Extension of the `hiero-gradle-conventions-plugins` project**

This pull request updates team membership and repository access configuration in `config.yaml`. The main changes are the addition of new team members and maintainers, and the inclusion of a new repository with its associated team permissions.

Team membership updates:

* Added `jjohannes` as a maintainer and replaced `san-est` with `PavelSBorisov` as a member in the `github-maintainers` team.

Repository configuration updates:

* Added the `hiero-java-project-template` repository and assigned appropriate team permissions, including maintain, write, and triage roles for relevant teams.
