### PR TITLE
backwards-compatibility.md created

### DIFF
--- a/guidelines/backwards-compatibility.md
+++ b/guidelines/backwards-compatibility.md
@@ -59,11 +59,11 @@ version number of 1.X or bigger.
   be implemented in a way that does not break existing functionality.
   For example and not limited to:
     * Adding new methods when a return type must be changed
-    * Adding parameters to methods with default values is acceptable if behaviour isn’t changed when parameters aren’t
+    * Adding parameters to methods with default values is acceptable if behavior remains unchanged when parameters aren’t
     supplied
 * APIs and data structures should follow versioning best practices to avoid disruption, for example:
     * Changes to return data structures should be additive, not subtractive
-    * New API parameters should be defaulted without changes to behaviour if not provided
+    * New API parameters should be defaulted without changes to behavior if not provided
 * Changes to response codes (in remote connections) are considered breaking changes
 
 ## Breaking Changes Process


### PR DESCRIPTION
This pull request introduces a new document, `guidelines/backwards-compatibility.md`, which establishes Hiero's official guidelines and procedures for handling backwards compatibility and breaking changes across its projects. The document outlines principles, processes, and communication standards to ensure stability for users and developers, while allowing for necessary evolution of the software.

This PR is mostly based on the great work of @rbair23 and @exploreriii 