### PR TITLE
chore: new python sdk triage member proposal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -199,6 +199,12 @@ teams:
       - aceppaluni
       - emiliyank
       - Akshat8510
+      - Mounil2005
+      - parvninama
+      - drtoxic69
+      - prajeeta15
+      - undefinedIsMyLife
+      - cheese-cakee
   - name: hiero-did-sdk-js-maintainers
     maintainers:
       - AlexanderShenshin


### PR DESCRIPTION
Proposal to expand the read-only Junior Committer team at the python sdk with:

- [Mounil2005](https://github.com/Mounil2005) 
- [parvninama](https://github.com/parvninama)
[parvninama](https://github.com/parvninama)
- [drtoxic69](https://github.com/drtoxic69)
- [prajeeta15](https://github.com/prajeeta15)
- [undefinedIsMyLife](https://github.com/undefinedIsMyLife)
- [cheese-cakee](https://github.com/cheese-cakee)
They have each made extremely valuable code contributions and show strong motivation to gain further skills 

Abilities and responsibilities :
- Coding
- Mentoring new starters
- Assigning / labelling / creating issues
- Reviewing pull requests
- Approving and requesting changes for pull requests (read-only)
