### PR TITLE
chore: new committers python SDK proposal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -187,6 +187,10 @@ teams:
       - hendrikebbers
       - Dosik13
       - manishdait
+      - Adityarya11
+      - MonaaEid
+      - aceppaluni
+      - AntonioCeppellini
   - name: hiero-sdk-python-triage
     maintainers:
       - nadineloepfe


### PR DESCRIPTION
Proposal to expand the Committer team at the python sdk with:

[Adityarya11](https://github.com/Adityarya11)
[MonaaEid](https://github.com/MonaaEid)
[aceppaluni](https://github.com/aceppaluni)
[AntonioCeppellini](https://github.com/AntonioCeppellini)

They each show long-term interest in the python SDK.

They have each made extremely valuable code contributions across a breadth of areas in the Python SDK, as well as have created issues, reviewed and approved pull requests and mentored new starters.
They each show responsibility and skills for open-source stewardship. 

They have already shown skills in:
Coding across various areas
Mentoring new starters
Assigning / labelling / creating issues
Reviewing pull requests
Approving and requesting changes for pull requests (read-only)
