### PR TITLE
chore: add hiero-good-first-issue-support to hiero-sdk-js

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1145,6 +1145,7 @@ repositories:
     teams:
       tsc: maintain
       github-maintainers: maintain
+      hiero-sdk-good-first-issue-support: triage
       hiero-sdk-js-maintainers: maintain
       hiero-sdk-js-committers: write
       hiero-sdk-js-internal-contributors: triage


### PR DESCRIPTION
This PR adds the `hiero-sdk-good-first-issue-support` team to `hiero-sdk-js`.