### PR TITLE
Update Hiero identity projects teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -208,22 +208,26 @@ teams:
       - KononovAndrey
       - dmueller2001
       - drgorb
+      - Toktar
   - name: hiero-did-sdk-js-committers
     maintainers:
       - Reccetech
     members:
       - KononovAndrey
+      - tajang97
   - name: hiero-did-sdk-python-maintainers
     maintainers:
       - Reccetech
     members:
       - AlexanderShenshin
       - dmueller2001
+      - Toktar
   - name: hiero-did-sdk-python-committers
     maintainers:
       - Reccetech
     members:
       - paulo-caldas
+      - tajang97
   - name: hiero-sdk-rust-maintainers
     maintainers:
       - RickyLB
@@ -689,13 +693,14 @@ teams:
       - Harasz
       - ChangoBuitrago
       - AlexanderShenshin
+      - Toktar
   - name: identity-collaboration-hub-committers
     maintainers:
       - Reccetech
       - AlexanderShenshin
     members:
       - ChangoBuitrago
-      - Toktar
+      - tajang97
   - name: hiero-improvement-proposals-maintainers
     maintainers:
       - sergmetelin


### PR DESCRIPTION
I'd like to request few updates for teams in identity-related projects ([Hiero DID SDK JS](https://github.com/hiero-ledger/hiero-did-sdk-js), [Hiero DID SDK Python](https://github.com/hiero-ledger/hiero-did-sdk-python), [Hiero Identity Collaboration Hub](https://github.com/hiero-ledger/identity-collaboration-hub)).

Changes:
- Added new committer from DSR team - @tajang97
- Added @Toktar to maintainer teams for all projects