### PR TITLE
chore: add olsentorfinn to solo committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -888,6 +888,7 @@ teams:
       - leninmehedy
     members:
       - matteriben
+      - olsentorfinn
       - JeffreyDallas
       - Ivo-Yankov
       - instamenta
@@ -899,7 +900,6 @@ teams:
       - jeromy-cannon
       - leninmehedy
     members:
-      - olsentorfinn
       - JeffreyDallas
       - Ivo-Yankov
       - instamenta


### PR DESCRIPTION
**Description**:

Add `olsentorfinn` to `solo-committers` group.

**Related Issue(s)**:

Implements #504
