### PR TITLE
chore: add aceppaluni to website committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -814,6 +814,7 @@ teams:
       - hendrikebbers
     members:
       - exploreriii
+      - aceppaluni
   - name: homebrew-tools-maintainers
     maintainers:
       - rbarker-dev


### PR DESCRIPTION
The Hiero website needs active committers

Proposal to add @aceppaluni to committers

They have attended most Hiero website community calls and has been helping to review issues, and is well aware of the hiero ecosystem


