### PR TITLE
chore: Add hiero-automation team with write permissions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1368,6 +1368,7 @@ repositories:
   - name: homebrew-tools
     teams:
       tsc: maintain
+      hiero-automation: write
       github-maintainers: maintain
       homebrew-tools-maintainers: maintain
       homebrew-tools-committers: write


### PR DESCRIPTION
Add `hiero-automation` to `homebrew-tools` repo with write permissions.