### PR TITLE
add gfi support team to swift sdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1187,6 +1187,7 @@ repositories:
     teams:
       tsc: maintain
       github-maintainers: maintain
+      hiero-sdk-good-first-issue-support: triage
       hiero-sdk-swift-maintainers: maintain
       hiero-sdk-swift-committers: write
       security-maintainers: triage


### PR DESCRIPTION
This PR grants triage privileges to the Hiero GFI Support team for the Hiero Swift SDK