### PR TITLE
chore: add akugal as consensus node committer and foundation code owner

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -425,6 +425,7 @@ teams:
       - aderevets
       - AlexKehayov
       - akdev
+      - akugal
       - anastasiya-kovaliova
       - anthony-swirldslabs
       - artemananiev
@@ -569,6 +570,7 @@ teams:
       - thenswan
       - anthony-swirldslabs
       - rsinha
+      - akugal
   - name: hiero-consensus-specifications-maintainers
     maintainers:
       - kantorcodes


### PR DESCRIPTION
Signed-off-by: Jeffrey Morgan <jeffrey.morgan@swirldslabs.com>

Propose to add akugal to hiero-consensus-node-committers and hiero-consensus-node-foundation-codeowners. He's been making contributions tothe team for 9 months now. Please vote for his addition.