### PR TITLE
chore: add Shivam as triage member to hiero website

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -826,6 +826,7 @@ teams:
       - hendrikebbers
     members:
       - Shivam-Batham
+      - Abhijeet2409
   - name: homebrew-tools-maintainers
     maintainers:
       - rbarker-dev


### PR DESCRIPTION
**Description**:
The hiero website can benefit from junior committers (triage member)

responsibilities would include:
- managing issue labels
- closing completed issues
- assigning users
- reviewing PRs
Permissions would extend to read-only

I would like to propose Shivam to be a triage member
https://github.com/Shivam-Batham
