### PR TITLE
add jan-milenkov to maintaners, remove mentions of instamenta due to a github username rename

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -888,17 +888,18 @@ teams:
     members:
       - jeromy-cannon
       - leninmehedy
+      - jan-milenkov
   - name: solo-committers
     maintainers:
       - nathanklick
       - jeromy-cannon
       - leninmehedy
+      - jan-milenkov
     members:
       - matteriben
       - olsentorfinn
       - JeffreyDallas
       - Ivo-Yankov
-      - instamenta
       - alex-kuzmin-hg
       - deshmukhpranali
   - name: solo-internal-contributors
@@ -906,10 +907,10 @@ teams:
       - nathanklick
       - jeromy-cannon
       - leninmehedy
+      - jan-milenkov
     members:
       - JeffreyDallas
       - Ivo-Yankov
-      - instamenta
       - alex-kuzmin-hg
       - deshmukhpranali
   - name: tsc-eligibility-check-admins


### PR DESCRIPTION
# Description

* Add `jan-milenkov` to `solo-maintainers`, `solo-committers`, and `solo-internal-contributors` teams
* Remove mentions of `instamenta`, due to a recent GitHub username change

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
