### PR TITLE
chore: add abhijeet and shivam to triage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -821,6 +821,12 @@ teams:
     members:
       - exploreriii
       - aceppaluni
+  - name: hiero-website-triage
+    maintainers:
+      - hendrikebbers
+    members:
+      - Shivam-Batham
+      - Abhijeet2409
   - name: homebrew-tools-maintainers
     maintainers:
       - rbarker-dev
@@ -1062,6 +1068,7 @@ repositories:
       github-maintainers: maintain
       hiero-website-maintainers: maintain
       hiero-website-committers: write
+      hiero-website-triage: triage
       hiero-sdk-good-first-issue-support: triage
       security-maintainers: triage
       prod-security: triage


### PR DESCRIPTION
Proposal to add Abhijeet and Shivam to triage role in the website

The hiero website can benefit from junior committers (triage member)

responsibilities would include:

managing issue labels
closing completed issues
assigning users
reviewing PRs
Permissions would extend to read-only

i would like to propose:
https://github.com/Shivam-Batham
https://github.com/Abhijeet2409

