### PR TITLE
Update on roles & groups

### DIFF
--- a/roles/roles-and-groups.md
+++ b/roles/roles-and-groups.md
@@ -254,7 +254,7 @@ To nominate `bob456` as a new committer for the PROJECT, update the `config.yaml
           - user6
           - bob456  # New committer being added
 
-#### Example: Adding a New Junior Committer
+### Example: Adding a New Junior Committer
 
 To nominate `carol789` as a new junior committer for the PROJECT, update the `config.yaml` file by adding their GitHub username to the `members` section of the `PROJECT-junior-committers` team:
 


### PR DESCRIPTION
This pull request makes significant updates to the documentation for roles and teams in the Hiero project. The changes clarify the definitions and processes for project roles, introduce a new Junior Committer role, and provide detailed guidelines on the structure and management of GitHub teams and roles. The documentation is now more comprehensive and precise, making it easier for contributors to understand how to participate and advance within the project.

**Major updates to project roles and responsibilities:**

- Added a new **Junior Committer** role to bridge the gap between Contributors and Committers, with clear eligibility, rights (GitHub Triage), and removal processes.
- Clarified and expanded the definitions and eligibility criteria for Contributors, Committers, and Maintainers, including nomination, voting, and removal procedures for each role.
- Provided explicit guidelines for adding and removing people from roles via PRs to the `config.yaml` file, including example YAML snippets. [[1]](diffhunk://#diff-86fabe6aa6f2506697f60cd4407d9005b58bdaec1a22f61719aa2343f60a382eL3-R185) [[2]](diffhunk://#diff-86fabe6aa6f2506697f60cd4407d9005b58bdaec1a22f61719aa2343f60a382eL97-R221) [[3]](diffhunk://#diff-86fabe6aa6f2506697f60cd4407d9005b58bdaec1a22f61719aa2343f60a382eL126-R240)

**Improvements to teams and GitHub access management:**

- Replaced references to "groups" with "teams" throughout the documentation, aligning terminology with GitHub conventions. [[1]](diffhunk://#diff-86fabe6aa6f2506697f60cd4407d9005b58bdaec1a22f61719aa2343f60a382eL3-R185) [[2]](diffhunk://#diff-86fabe6aa6f2506697f60cd4407d9005b58bdaec1a22f61719aa2343f60a382eL97-R221)
- Documented the structure and purpose of per-project teams (`PROJECT-maintainers`, `PROJECT-committers`, `PROJECT-junior-committers`, and codeowners teams), as well as global teams for automation, security, and governance.
- Detailed the mapping of GitHub roles (Maintain, Write, Triage) to the respective teams and provided guidance on additional roles for onboarding and project management.

**Clarifications and examples:**

- Updated and expanded example YAML snippets to reflect the new team structure, including how to add Junior Committers and the correct usage of `maintainers` and `members` fields. [[1]](diffhunk://#diff-86fabe6aa6f2506697f60cd4407d9005b58bdaec1a22f61719aa2343f60a382eL97-R221) [[2]](diffhunk://#diff-86fabe6aa6f2506697f60cd4407d9005b58bdaec1a22f61719aa2343f60a382eL126-R240)
- Clarified the distinction between the `maintainers` and `members` sections in the team definitions for clowarden.

These changes enhance the clarity, inclusiveness, and maintainability of the project's governance documentation.