### PR TITLE
chore: Add hiero-automation team with write permissions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1211,6 +1211,7 @@ repositories:
     teams:
       tsc: maintain
       github-maintainers: maintain
+      hiero-automation: write
       hiero-sdk-good-first-issue-support: triage
       hiero-sdk-python-maintainers: maintain
       hiero-sdk-python-committers: write


### PR DESCRIPTION
## Description

For [hiero-sdk-python #1775](https://github.com/hiero-ledger/hiero-sdk-python/issues/1775) we need to add hiero-automation to the `hiero-sdk-python` repo

## Related issue(s)

Fixes #531

