### PR TITLE
chore: add Akshat to committers and remove from triage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -192,6 +192,7 @@ teams:
       - MonaaEid
       - aceppaluni
       - AntonioCeppellini
+      - Akshat8510
   - name: hiero-sdk-python-triage
     maintainers:
       - nadineloepfe
@@ -203,7 +204,6 @@ teams:
       - Adityarya11
       - aceppaluni
       - emiliyank
-      - Akshat8510
       - Mounil2005
       - parvninama
       - drtoxic69


### PR DESCRIPTION
Proposal to add Akshat to the Python SDK committer members

https://github.com/Akshat8510

Akshat has been a regular contributing member to the Python SDK in multiple areas:
- creating PRs
- reviewing PRs
- mentoring starters
- helping to keep the repository organised
- attending community calls 
They have shown great responsibility, and will be a great addition to the committer team