### PR TITLE
Add @hiero-ledger/tsc to config.yaml ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 *.md           @hiero-ledger/lf-staff @hiero-ledger/github-maintainers @hiero-ledger/tsc
 /elections/     @hiero-ledger/tsc
-config.yaml     @hiero-ledger/lf-staff @hiero-ledger/github-maintainers
+config.yaml     @hiero-ledger/lf-staff @hiero-ledger/github-maintainers @hiero-ledger/tsc


### PR DESCRIPTION
This pull request updates the ownership assignment for the `config.yaml` file in the `CODEOWNERS` file, adding the `@hiero-ledger/tsc` team as an owner alongside the existing teams.