### PR TITLE
chore: add Akshat to GFI support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -127,6 +127,7 @@ teams:
       - rwalworth
       - MonaaEid
       - tech0priyanshu
+      - Akshat8510
   - name: hiero-mirror-node-committers
     maintainers:
       - steven-sheehy


### PR DESCRIPTION
The GFI support team can benefit from more members as GFI are being supported by more repositories:
- python
- c++
- swift
- javascript
and there are further interest.


Akshat is a long-time contributor of the Python SDK and has always gone the extra mile to support new starters in a friendly way, and has been reviewing pull requests quite consistently. Also has experience in js/java/rust.

[Akshat8510](https://github.com/Akshat8510)
