### PR TITLE
Add roadmap-viewers group

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1068,6 +1068,7 @@ teams:
       - rbair23
   - name: roadmap-committers
     maintainers:
+      - a-saksena
       - steven-sheehy
     members:
       - akdev
@@ -1082,6 +1083,16 @@ teams:
       - Reccetech
       - SimiHunjan
       - ty-swirldslabs
+  - name: roadmap-viewers
+    maintainers:
+      - a-saksena
+      - steven-sheehy
+    members:
+      - berryware
+      - imalygin
+      - quiet-node
+      - timfn-hg
+      - timo0
   - name: hiero-enterprise-java-maintainers
     maintainers:
       - hendrikebbers
@@ -1524,6 +1535,7 @@ repositories:
       github-maintainers: maintain
       roadmap-maintainers: maintain
       roadmap-committers: write
+      roadmap-viewers: read
       security-maintainers: triage
       prod-security: triage
       sec-ops: triage


### PR DESCRIPTION
**Description**:

Add a temporary roadmap-viewers group during the PoC phase so interested parties can view the private roadmap.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
