### PR TITLE
chore(vote): Add cliffclick to the list of contributors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -457,6 +457,7 @@ teams:
       - anthony-swirldslabs
       - artemananiev
       - bubo
+      - cliffclick
       - david-bakin-sl
       - derektriley
       - edward-swirldslabs


### PR DESCRIPTION
## Description

This pull request adds a new team member to the configuration.

- Added `cliffclick` to the `teams` list in `config.yaml` to include them as part of the team.

## Related Issue(s)

N/A