### PR TITLE
chore: Add cweagans to maintainers list in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1164,6 +1164,7 @@ teams:
       - djsplice
       - nlindellalderman
       - tomzhenghedera
+      - cweagans
   - name: hiero-enterprise-java-maintainers
     maintainers:
       - hendrikebbers


### PR DESCRIPTION
## Description

This pull request makes a small update to the `config.yaml` file, adding a new team member to the list of maintainers. The change assigns `cweagans` as a committer in the `teams` section.

## Related Issue(s)

N/A