### PR TITLE
Update Hiero identity projects maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -216,6 +216,8 @@ teams:
       - dmueller2001
       - drgorb
       - Toktar
+      - ashcherbakov
+      - Artemkaaas
   - name: hiero-did-sdk-js-committers
     maintainers:
       - Reccetech
@@ -229,6 +231,8 @@ teams:
       - AlexanderShenshin
       - dmueller2001
       - Toktar
+      - ashcherbakov
+      - Artemkaaas
   - name: hiero-did-sdk-python-committers
     maintainers:
       - Reccetech
@@ -724,6 +728,8 @@ teams:
       - ChangoBuitrago
       - AlexanderShenshin
       - Toktar
+      - ashcherbakov
+      - Artemkaaas
   - name: identity-collaboration-hub-committers
     maintainers:
       - Reccetech
@@ -1093,6 +1099,8 @@ teams:
       - AlexanderShenshin
     members:
       - Toktar
+      - ashcherbakov
+      - Artemkaaas
   - name: heka-identity-platform-committers
     maintainers:
       - AlexanderShenshin


### PR DESCRIPTION
I'd like to request updates for maintainer teams in identity-related projects ([Hiero DID SDK JS](https://github.com/hiero-ledger/hiero-did-sdk-js), [Hiero DID SDK Python](https://github.com/hiero-ledger/hiero-did-sdk-python), [Hiero Identity Collaboration Hub](https://github.com/hiero-ledger/identity-collaboration-hub) and [Heka Identity Platform](https://github.com/hiero-ledger/heka-identity-platform)).

Changes:

- Added new maintainers from DSR team to all identity repositories - @ashcherbakov, @Artemkaaas