### PR TITLE
chore: added jaycoolh as a maintainer to the hiero-cli project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -640,7 +640,6 @@ teams:
       - matevszm
       - rozekmichal
       - mmyslblocky
-      - jaycoolh
   - name: hiero-docs-maintainers
     maintainers:
       - SimiHunjan

--- a/config.yaml
+++ b/config.yaml
@@ -629,6 +629,7 @@ teams:
       - devmab
       - mmyslblocky
       - misiek-blocky
+      - jaycoolh
   - name: hiero-cli-committers
     maintainers:
       - Neurone
@@ -639,6 +640,7 @@ teams:
       - matevszm
       - rozekmichal
       - mmyslblocky
+      - jaycoolh
   - name: hiero-docs-maintainers
     maintainers:
       - SimiHunjan


### PR DESCRIPTION
**Description**:
Adds hiero-cli contributor to `hiero-cli-maintainers` and `hiero-cli-committers` (`jaycoolh`), so that they can review and merge PRs.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)