### PR TITLE
chore: add sdk-triage to rust SDK

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1395,6 +1395,7 @@ repositories:
       github-maintainers: maintain
       hiero-sdk-rust-maintainers: maintain
       hiero-sdk-rust-committers: write
+      hiero-sdk-triage: triage
       hiero-triage: triage
       security-maintainers: triage
     visibility: public


### PR DESCRIPTION
This PR adds the `hiero-sdk-triage` team to the `hiero-sdk-rust` repo.