### PR TITLE
chore: add PavelSBorisov as hiero-gradle-conventions-committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -371,6 +371,7 @@ teams:
       - rbarker-dev
       - andrewb1269
     members:
+      - PavelSBorisov
       - san-est
   - name: hiero-block-node-maintainers
     maintainers:


### PR DESCRIPTION
**Description**:

@PavelSBorisov was is already acting in this role for months. Codeowner rules were not enforced in `hiero-gradle-conventions` until recently. That's why this got by unnoticed. 

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**
