### PR TITLE
chore: add ddeskov-limechain to solo-internal-contributors and solo-docs-committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -954,6 +954,7 @@ teams:
       - deshmukhpranali
       - SimiHunjan
       - boris-bonin
+      - ddeskov-limechain
   - name: solo-docs-admins
     maintainers:
       - nathanklick
@@ -979,6 +980,7 @@ teams:
       - Reccetech
     members:
       - boris-bonin
+      - ddeskov-limechain
   - name: tsc-eligibility-check-admins
     maintainers:
       - jwagantall


### PR DESCRIPTION
**Description**:
- add ddeskov-limechain to solo-internal-contributors and solo-docs-committers

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
