### PR TITLE
chore: add hiero-automation team to hiero-cryptography repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1580,4 +1580,5 @@ repositories:
       hiero-cryptography-maintainers: maintain
       hiero-cryptography-committers: write
       security-maintainers: triage
+      hiero-automation: write
     visibility: public


### PR DESCRIPTION
**Description**:

Add hiero-automation team to hiero-cryptography repository with write permissions.

**Related issue(s)**:

Fixes #644 
