### PR TITLE
Add viniciusjssouza to consensus node groups

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -207,6 +207,7 @@ teams:
       - timfn-hg
       - timo0
       - tinker-michaelj
+      - viniciusjssouza
       - vtronkov
   - name: hiero-consensus-node-consensus-codeowners
     maintainers:
@@ -250,6 +251,7 @@ teams:
       - thomas-swirlds-labs
       - timfn-hg
       - tinker-michaelj
+      - viniciusjssouza
       - vtronkov
   - name: hiero-consensus-node-foundation-codeowners
     maintainers:
@@ -275,7 +277,6 @@ teams:
       - Chinnmay
       - Grigorov-Georgi
       - SimiHunjan
-      - viniciusjssouza
   - name: hiero-consensus-node-maintainers
     maintainers:
       - Nana-EC


### PR DESCRIPTION
Adds viniciusjssouza to the requested consensus node groups and removes the existing internal-contributors entry. Validation: config.yaml parsed successfully.