### PR TITLE
Add diogper to consensus node committers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -180,6 +180,7 @@ teams:
       - cliffclick
       - david-bakin-sl
       - derektriley
+      - diogper
       - edward-swirldslabs
       - Evdokia-Georgieva
       - gkozyryatskyy


### PR DESCRIPTION
## Summary

- Add `diogper` to `hiero-consensus-node-committers` in spelling order.

## Validation

- Parsed `config.yaml` successfully with Ruby YAML.
- Verified `diogper` is listed in `hiero-consensus-node-committers`.