### PR TITLE
Update consensus node internal contributors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -272,8 +272,8 @@ teams:
       - aderevets
       - akugal
       - AlexKehayov
-      - Chinnmay
       - Grigorov-Georgi
+      - ruslanvelkov-beep
       - SimiHunjan
       - viniciusjssouza
   - name: hiero-consensus-node-maintainers


### PR DESCRIPTION
## Summary

- Remove `Chinnmay` from `hiero-consensus-node-internal-contributors`.
- Add `ruslanvelkov-beep` to `hiero-consensus-node-internal-contributors`.

## Validation

- Parsed `config.yaml` successfully with Ruby YAML.
- Verified `Chinnmay` is no longer listed and `ruslanvelkov-beep` is listed in the internal contributors group.