### PR TITLE
chore: culling inactive permission holders (150 days+)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -865,8 +865,6 @@ teams:
       - exploreriii
       - manishdait
     members:
-      - exploreriii
-      - manishdait
   - name: hiero-sdk-python-triage
     maintainers:
       - exploreriii

--- a/config.yaml
+++ b/config.yaml
@@ -850,7 +850,8 @@ teams:
       - venilinvasilev
   - name: hiero-sdk-python-committers
     maintainers:
-      - nadineloepfe
+      - exploreriii
+      - manishdait
     members:
       - aceppaluni
       - Adityarya11
@@ -861,22 +862,21 @@ teams:
       - parvninama
   - name: hiero-sdk-python-maintainers
     maintainers:
-      - nadineloepfe
+      - exploreriii
+      - manishdait
     members:
       - exploreriii
       - manishdait
   - name: hiero-sdk-python-triage
     maintainers:
       - exploreriii
-      - nadineloepfe
+      - manishdait
     members:
       - cheese-cakee
       - danielmarv
-      - drtoxic69
       - Mounil2005
       - prajeeta15
       - tech0priyanshu
-      - undefinedIsMyLife
   - name: hiero-sdk-rust-committers
     maintainers:
       - RickyLB


### PR DESCRIPTION
This PR clears permissions that are not actively used for over 150 days in the python sdk

<img width="1063" height="127" alt="Screenshot 2026-07-03 at 10 10 00" src="https://github.com/user-attachments/assets/7493aa31-8358-4aac-8d5d-ed9fdddb2fc9" />
