### PR TITLE
revert: remove Fantomasa and ddeskov-limechain from hiero-sdk-js-committers (PR #662 vote failed)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -846,8 +846,6 @@ teams:
       - ivaylonikolov7
       - mariodimitrovv
       - venilinvasilev
-      - Fantomasa
-      - ddeskov-limechain
   - name: hiero-sdk-js-maintainers
     maintainers:
       - SimiHunjan


### PR DESCRIPTION
## Reason

PR #662 added @Fantomasa and @ddeskov-limechain to \`hiero-sdk-js-committers\` but the GitVote on that PR did not pass: it closed at 50% (2/4 binding votes in favour) against the required 66.66% threshold.

This PR reverts those additions so the membership reflects only governance-approved roles. A separate PR will re-open a proper vote for both nominees.

## Changes

- Remove \`Fantomasa\` from \`hiero-sdk-js-committers\`
- Remove \`ddeskov-limechain\` from \`hiero-sdk-js-committers\`

This PR does not require a vote — it is correcting a procedural error, not making a new governance decision.