### PR TITLE
chore: add ddeskov-limechain and Fantomasa as committers for hiero-sdk-js

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -843,6 +843,8 @@ teams:
     members:
       - 0xivanov
       - agadzhalov
+      - ddeskov-limechain
+      - Fantomasa
       - ivaylonikolov7
       - mariodimitrovv
       - venilinvasilev

--- a/config.yaml
+++ b/config.yaml
@@ -846,8 +846,6 @@ teams:
       - ivaylonikolov7
       - mariodimitrovv
       - venilinvasilev
-      - Fantomasa
-      - ddeskov-limechain
   - name: hiero-sdk-js-maintainers
     maintainers:
       - SimiHunjan


### PR DESCRIPTION
## Nomination

This PR nominates two contributors as Committers for \`hiero-sdk-js\`.

> **Dependency:** This PR should only be merged after PR #668 (revert of failed vote PR #662) has merged.

## Nominees and contributions

**@ddeskov-limechain** — 7 merged PRs in hiero-sdk-js (April & July 2026):
- #4235 feat(TCK): add version JSON-RPC method to report the SDK under test
- #4233 fix: remove react-native-get-random-values from cryptography package
- #4230 fix: auto-estimate gas for ContractCallQuery
- #4229 refactor(cryptography): migrate primitives to Noble & Scure
- #4182 feat(TCK): add executeFeeEstimateQuery JSON-RPC method (HIP-1261)
- #3930 feat: add contractId support to HookEntityId
- #3928 feat: verify and document FileAppendTransaction chunk size limits
Also an existing Swift SDK maintainer.

**@Fantomasa** — 23 merged PRs in hiero-sdk-js (June & July 2026), including:
- #4257 chore(release): v2.86.1
- #4256 fix: add browser condition to package exports to fix esbuild browser bundling
- #4187 feat: setEthereumData(EthereumTransactionData) overload + never-submit-unsigned guard
- #4186 feat: typed accessors + structured access-list/authorization views for Ethereum transaction data
- #4183 feat: native sign(key) for Ethereum transaction data
- #4216 test: isolate node unit tests to fix flaky gRPC mocks
- #4217 chore(release): v2.86.0
- Plus 16 additional dependency, fix, and chore PRs

## Context

Both nominees were previously added via PR #662, but that PR's GitVote did not pass (50% vs 66.66% threshold). PR #668 reverts that change; this PR opens a proper vote.

## Vote

JS maintainers please cast your vote below.