### PR TITLE
chore: add ddeskov-limechain and Fantomasa as committers for hiero-sdk-js

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -843,6 +843,8 @@ teams:
     members:
       - 0xivanov
       - agadzhalov
+      - ddeskov-limechain
+      - Fantomasa
       - ivaylonikolov7
       - mariodimitrovv
       - venilinvasilev


### PR DESCRIPTION
## Summary

This PR proposes adding two contributors as Committers for `hiero-sdk-js`. A GitVote against this PR will be used to collect votes from the `hiero-sdk-js-maintainers` team.

## Nominees

| Nominee | JS SDK PRs | Notes |
|---|---|---|
| @ddeskov-limechain | 7 | Also holds committer/maintainer roles in other SDK repos |
| @Fantomasa | 23 | Highly active JS contributor |

## Background

Both nominees were previously added via PR #662, but that PR GitVote closed at 50% — below the 66.66% required threshold. PR #668 reverted those additions. This PR reopens the proper vote with a clean branch from main.

## Changes

- Add `ddeskov-limechain` to `hiero-sdk-js-committers`
- Add `Fantomasa` to `hiero-sdk-js-committers`

## Vote

To start the vote, a maintainer should comment:

```
/vote-hieroSdkJsMaintainers
```

Binding voters: members of `hiero-sdk-js-maintainers`. Passing threshold: 66.66% approval, 14-day window.