### PR TITLE
revert: undo unvoted python-sdk maintainer/committer changes from PR #663

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -863,21 +863,21 @@ teams:
       - Akshat8510
       - AntonioCeppellini
       - Dosik13
+      - MonaaEid
       - parvninama
-      - danielmarv
-      - Mounil2005
   - name: hiero-sdk-python-maintainers
     maintainers:
       - exploreriii
       - manishdait
     members:
-      - MonaaEid
   - name: hiero-sdk-python-triage
     maintainers:
       - exploreriii
       - manishdait
     members:
       - cheese-cakee
+      - danielmarv
+      - Mounil2005
       - prajeeta15
       - tech0priyanshu
   - name: hiero-sdk-rust-committers


### PR DESCRIPTION
## Reason

PR #663 made three role changes to the Python SDK teams:

- Promoted @MonaaEid from `hiero-sdk-python-committers` to `hiero-sdk-python-maintainers`
- Promoted @danielmarv and @Mounil2005 from `hiero-sdk-python-triage` to `hiero-sdk-python-committers`

That PR was merged with **no GitVote at all** — it was merged on the basis of two PR approvals, with the comment *"Approving since we have majority of maintainers votes via PR approval"*. A PR approval is not a governance vote. With 2 maintainers on the team, the 66.66% threshold means both maintainers must cast a formal vote — a threshold that was never even tested here, because no vote was opened.

For comparison, PR #662 (JS SDK committers) followed the correct process: a GitVote was opened, it closed at 50% (2/4 binding votes) against the required 66.66%, and the additions were reverted.

## Precedent — how a revert is managed without a vote (PR #668)

PR #668 established exactly the process this PR follows. It reverted the #662 additions **without opening a new vote**, stating:

> *"This PR does not require a vote — it is correcting a procedural error, not making a new governance decision."*

The same reasoning applies here, with an even stronger basis: #662 at least held a vote that failed, while #663 held **no vote at all**. If the rules are applied consistently — as they were in #668 — role changes that lack a passing vote cannot stand.

## Changes

- Move `MonaaEid` from `hiero-sdk-python-maintainers` back to `hiero-sdk-python-committers`
- Move `danielmarv` and `Mounil2005` from `hiero-sdk-python-committers` back to `hiero-sdk-python-triage`

This is a clean `git revert` of merge commit `3577842` and restores the exact state prior to #663.

## Notes

This revert makes no judgement on the nominees themselves. A separate PR can re-propose these promotions with a proper GitVote, exactly as is being done for the #662 nominees.
