### PR TITLE
chore: add alex-au to roadmap-viewers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1063,6 +1063,7 @@ teams:
     members:
       - abies
       - akugal
+      - alex-au
       - anthony-swirldslabs
       - artemananiev
       - arturre


### PR DESCRIPTION
Add `alex-au` to the `roadmap-viewers` team.
