### PR TITLE
Add new maintianers for the hiero-sdk-python

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -871,13 +871,11 @@ teams:
       - exploreriii
       - manishdait
     members:
-      - aceppaluni
       - Adityarya11
       - Akshat8510
       - AntonioCeppellini
       - Dosik13
       - parvninama
-      - danielmarv
       - Mounil2005
   - name: hiero-sdk-python-maintainers
     maintainers:
@@ -885,6 +883,8 @@ teams:
       - manishdait
     members:
       - MonaaEid
+      - aceppaluni
+      - danielmarv
   - name: hiero-sdk-python-triage
     maintainers:
       - exploreriii


### PR DESCRIPTION
**Description**:
This PR propose adding new maintainers to  the hiero-sdk-python.

**Changes Made**
- Added `aceppaluni` and `danielmarv` to hiero-sdk-python-maintainers
- Remove `aceppaluni` and `danielmarv` from hiero-sdk-python-commiters

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
