### PR TITLE
chore: remove inactive permission holders in hiero website

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1003,7 +1003,6 @@ teams:
       - hendrikebbers
     members:
       - Abhijeet2409
-      - Shivam-Batham
   - name: homebrew-tools-committers
     maintainers:
       - andrewb1269


### PR DESCRIPTION
Culls inactive permission holders since 6 months for hiero website

ignores other teams:
- security maintainers
- good first issue support