### PR TITLE
chore: removing inactive permission holders for cpp sdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -799,7 +799,6 @@ teams:
     maintainers:
       - rwalworth
     members:
-      - agadzhalov
       - gsstoykov
   - name: hiero-sdk-cpp-maintainers
     maintainers:


### PR DESCRIPTION
Culls inactive committers or maintainers in the c++ sdk (at least 6 months of no activity)




