### PR TITLE
chore: culling inactive permission holders in java sdk pass 1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -839,14 +839,12 @@ teams:
     members:
       - 0xivanov
       - agadzhalov
-      - emiliyank
   - name: hiero-sdk-java-maintainers
     maintainers:
       - SimiHunjan
     members:
       - 0xivanov
       - agadzhalov
-      - emiliyank
       - mustafauzunn
   - name: hiero-sdk-js-committers
     maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -835,7 +835,7 @@ teams:
       - tech0priyanshu
   - name: hiero-sdk-java-committers
     maintainers:
-      - naydenovn
+      - SimiHunjan
     members:
       - 0xivanov
       - agadzhalov


### PR DESCRIPTION
Proposal to cull permission holders that have been inactive for the last 6 months.

Note:
naydenovn is inactive but listed as a maintainer of the committer team. They are proposed replaced by the maintainer of the maintainer team that is active in the last 6 months.