### PR TITLE
chore: remove inactive permission holders in rust sdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -895,15 +895,12 @@ teams:
       - tech0priyanshu
   - name: hiero-sdk-rust-committers
     maintainers:
-      - RickyLB
+      - gsstoykov
     members:
-      - agadzhalov
       - ivaylonikolov7
   - name: hiero-sdk-rust-maintainers
     maintainers:
       - gsstoykov
-      - RickyLB
-      - Sheng-Long
     members:
       - SimiHunjan
   - name: hiero-sdk-swift-committers


### PR DESCRIPTION
Culling permission holders that have been inactive in the rust sdk for more than 6 months.

This leaves no maintainers for the committer team, in which case the maintainer for the maintainer team is used to substitute
