### PR TITLE
chore: culling inactive permission holders for swift sdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -908,7 +908,7 @@ teams:
       - SimiHunjan
   - name: hiero-sdk-swift-committers
     maintainers:
-      - RickyLB
+      - rwalworth
     members:
       - izik
   - name: hiero-sdk-swift-maintainers


### PR DESCRIPTION
Culls permission holders that have been inactive for at least 6 months in the swift sdk

This includes a maintainer of the committer team, in which case they have been substituted by the maintainer of the maintainer team