### PR TITLE
chore: cull inactive permission holders block node

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -121,8 +121,6 @@ teams:
       - ivannov
       - jasperpotts
       - jsync-swirlds
-      - mattp-swirldslabs
-      - mustafauzunn
       - rbair23
       - rbarker-dev
       - rockysingh


### PR DESCRIPTION
Proposal to cull permission holders that have been inactive in the repo for at least 6 months


