### PR TITLE
chore: cull inactive permission holders hiero cli pass 1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -157,7 +157,6 @@ teams:
       - Neurone
     members:
       - devmab
-      - jaycoolh
       - misiek-blocky
       - mmyslblocky
       - piotrswierzy


### PR DESCRIPTION
Proposal to cull inactive permission holders, inactive in the last 6 months+ in hiero cli 

Note: this is pass 1

neurone is inactive but a maintainer of both teams
A decision will need to be made and a subsequent PR if maintainers want to replace this inactive member