### PR TITLE
chore: cull inactive (6months+) permission holders hiero consensus sp…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -353,19 +353,14 @@ teams:
       - itsbrandondev
       - kantorcodes
     members:
-      - chelleswf
       - HGraphPunks
-      - rocketmay
-      - sentx-dev
       - teacoat
   - name: hiero-consensus-specifications-maintainers
     maintainers:
       - itsbrandondev
       - kantorcodes
     members:
-      - chelleswf
       - HGraphPunks
-      - rocketmay
   - name: hiero-contracts-committers
     maintainers:
       - Ferparishuertas


### PR DESCRIPTION
Proposal to cull inactive permission holders in the hiero consensus specification repo, for 6 months+ of inactivity
