### PR TITLE
chore: culling inactive crytography committers and maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -424,12 +424,7 @@ teams:
     maintainers:
       - anthony-swirldslabs
       - rsinha
-    members:
-      - akugal
-      - imalygin
-      - mxtartaglia-sl
-      - thenswan
-      - timo0
+    members: []
   - name: hiero-cryptography-maintainers
     maintainers:
       - anthony-swirldslabs


### PR DESCRIPTION
Proposal to cull those holding permissions in the cryptography committers and maintainer teams if inactive 6 months+ 
