### PR TITLE
chore: cull inactive 6 months+ did sdk js

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -448,19 +448,12 @@ teams:
     maintainers:
       - Reccetech
     members:
-      - KononovAndrey
       - tajang97
   - name: hiero-did-sdk-js-maintainers
     maintainers:
       - AlexanderShenshin
       - Reccetech
     members:
-      - Artemkaaas
-      - ashcherbakov
-      - Diegoescalonaro
-      - dmueller2001
-      - drgorb
-      - KononovAndrey
       - Toktar
   - name: hiero-did-sdk-maintainers
     maintainers:


### PR DESCRIPTION
Proposal to cull inactive permission holders (6 months+) in did sdk js

Reccetech is also inactive - a decision will be made who to replace as maintainer if desired