### PR TITLE
chore: cull inactive permission holders 6 months+ did sdk python

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -477,17 +477,12 @@ teams:
   - name: hiero-did-sdk-python-committers
     maintainers:
       - Reccetech
-    members:
-      - paulo-caldas
-      - tajang97
+    members: []
   - name: hiero-did-sdk-python-maintainers
     maintainers:
       - Reccetech
     members:
       - AlexanderShenshin
-      - Artemkaaas
-      - ashcherbakov
-      - dmueller2001
       - Toktar
   - name: hiero-docs-committers
     maintainers:


### PR DESCRIPTION
Proposal to cull inactive (6 months + ) permission holders in did sdk python

Reccetech is also inactive - a decision will be made who to replace as maintainer if desired