### PR TITLE
chore: cull inactive permission holders hiero mirror node

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -737,12 +737,9 @@ teams:
     members:
       - ashumahajan
       - bilyana-gospodinova
-      - filev94
       - IvanKavaldzhiev
       - jnels124
-      - kselveliev
       - martingeorgiev1
-      - nickeynikolovv
       - nirbosl
       - sdimitrov9
   - name: hiero-mirror-node-explorer-committers


### PR DESCRIPTION
Config yaml defines:
```
  - name: hiero-mirror-node
    teams:
      github-maintainers: maintain
      hiero-automation: write
      hiero-gradle-conventions-maintainers: write
      hiero-mirror-node-automation: admin
      hiero-mirror-node-committers: write
      hiero-mirror-node-maintainers: admin
      hiero-triage: triage
      security-maintainers: triage
      tsc: maintain
```

This pr proposes culling inactive permission holders for 6+ months for:
```
  - name: hiero-mirror-node
    teams:
      hiero-mirror-node-committers: write
      hiero-mirror-node-maintainers: admin
```