### PR TITLE
chore: cull inactive permission holders hiero gradle conventions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -558,7 +558,7 @@ teams:
     maintainers:
       - andrewb1269
       - rbarker-dev
-    members:
+    members: []
   - name: hiero-gradle-conventions-maintainers
     maintainers:
       - andrewb1269

--- a/config.yaml
+++ b/config.yaml
@@ -559,7 +559,6 @@ teams:
       - andrewb1269
       - rbarker-dev
     members:
-      - san-est
   - name: hiero-gradle-conventions-maintainers
     maintainers:
       - andrewb1269


### PR DESCRIPTION
Config yaml defines:
```
  - name: hiero-gradle-conventions
    teams:
      github-maintainers: maintain
      hiero-gradle-conventions-committers: write
      hiero-gradle-conventions-maintainers: maintain
      security-maintainers: triage
      tsc: maintain
    visibility: public
```

This proposal is to cull inactive permission holders in
```
  - name: hiero-gradle-conventions
    teams:
      hiero-gradle-conventions-committers: write
      hiero-gradle-conventions-maintainers: maintain
    visibility: public
```