### PR TITLE
chore: cull inactive permission holders hiero triage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -972,8 +972,6 @@ teams:
     members:
       - aceppaluni
       - akdev
-      - atul-hedera
-      - cweagans
       - dalvizu
       - Ferparishuertas
       - Jeffrey-morgan34


### PR DESCRIPTION
Hiero triage is:
```
  - name: hiero-triage
    maintainers:
      - a-saksena
      - nathanklick
      - rbair23
    members:
      - aceppaluni
      - akdev
      - dalvizu
      - Ferparishuertas
      - Jeffrey-morgan34
      - Mark-Swirlds
      - Nana-EC
      - Reccetech
      - SimiHunjan
      - steven-sheehy
      - ty-swirldslabs
  ```

This team has triage permissions across many areas in hiero ledger.

Proposing culling this team if the team members have no activity in any of their designated repositories for 6+ months

Vote has to be far-reaching