### PR TITLE
chore: cull identity collaboration hub

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1027,8 +1027,8 @@ teams:
     members:
   - name: identity-collaboration-hub-maintainers
     maintainers:
-    members:
       - AlexanderShenshin
+    members:
       - Toktar
   - name: lf-staff
     maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -1024,20 +1024,11 @@ teams:
   - name: identity-collaboration-hub-committers
     maintainers:
       - AlexanderShenshin
-      - Reccetech
     members:
-      - ChangoBuitrago
-      - tajang97
   - name: identity-collaboration-hub-maintainers
     maintainers:
-      - dmueller2001
-      - Reccetech
     members:
       - AlexanderShenshin
-      - Artemkaaas
-      - ashcherbakov
-      - ChangoBuitrago
-      - Harasz
       - Toktar
   - name: lf-staff
     maintainers:


### PR DESCRIPTION
Config yaml defines:
```
  - name: identity-collaboration-hub
    teams:
      github-maintainers: maintain
      identity-collaboration-hub-committers: write
      identity-collaboration-hub-maintainers: maintain
      security-maintainers: triage
      tsc: maintain
```

This proposes culling all permission holders without activity for 6+ months in these areas
```
  - name: identity-collaboration-hub
    teams:
      identity-collaboration-hub-committers: write
      identity-collaboration-hub-maintainers: maintain
```

Note this includes 2x maintainers, so the maintainer of the committer is proposed as the maintainer for the maintainers.

