### PR TITLE
chore: cull inactivity did sdk shared teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -439,10 +439,7 @@ teams:
       - pratyay85
   - name: hiero-did-sdk-committers
     maintainers:
-      - Reccetech
     members:
-      - KononovAndrey
-      - paulo-caldas
       - tajang97
   - name: hiero-did-sdk-js-committers
     maintainers:
@@ -465,14 +462,7 @@ teams:
   - name: hiero-did-sdk-maintainers
     maintainers:
       - AlexanderShenshin
-      - Reccetech
     members:
-      - Artemkaaas
-      - ashcherbakov
-      - Diegoescalonaro
-      - dmueller2001
-      - drgorb
-      - KononovAndrey
       - Toktar 
   - name: hiero-did-sdk-python-committers
     maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -439,6 +439,7 @@ teams:
       - pratyay85
   - name: hiero-did-sdk-committers
     maintainers:
+      - AlexanderShenshin
     members:
       - tajang97
   - name: hiero-did-sdk-js-committers


### PR DESCRIPTION
This PR proposes to cull inactive (6+ months) permission holders in did sdk shared teams.

Note this leaves the committer team with no maintainer, so the proposal is to make the maintainer of the maintainer adopt that.

This team has permissions to influence both js and python did sdk  as seen here:
```
  - name: hiero-did-sdk-js
    teams:
      github-maintainers: maintain
      hiero-did-sdk-js-committers: write
      hiero-did-sdk-js-maintainers: maintain
      hiero-did-sdk-committers: write
      hiero-did-sdk-maintainers: maintain
      security-maintainers: triage
      tsc: maintain
    visibility: public
  - name: hiero-did-sdk-python
    teams:
      github-maintainers: maintain
      hiero-did-sdk-python-committers: write
      hiero-did-sdk-python-maintainers: maintain
      hiero-did-sdk-committers: write
      hiero-did-sdk-maintainers: maintain
      security-maintainers: triage
      tsc: maintain
```
