### PR TITLE
chore: cull inactive permission holders hiero json rpc relay

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -683,6 +683,7 @@ teams:
   - name: hiero-json-rpc-relay-maintainers
     maintainers:
       - Ferparishuertas
+      - Nana-EC
     members:
       - konstantinabl
       - natanasow

--- a/config.yaml
+++ b/config.yaml
@@ -667,9 +667,8 @@ teams:
     maintainers:
       - Ferparishuertas
     members:
-      - Ivo-Yankov
+      - AlfredoG87
       - jasuwienas
-      - konstantinabl
       - natanasow
       - quiet-node
       - simzzz

--- a/config.yaml
+++ b/config.yaml
@@ -685,7 +685,6 @@ teams:
       - Ferparishuertas
       - Nana-EC
     members:
-      - konstantinabl
       - natanasow
       - quiet-node
       - simzzz

--- a/config.yaml
+++ b/config.yaml
@@ -666,39 +666,25 @@ teams:
   - name: hiero-json-rpc-relay-committers
     maintainers:
       - Ferparishuertas
-      - Nana-EC
     members:
-      - acuarica
-      - AlfredoG87
-      - ebadiere
-      - georgi-l95
-      - isavov
       - Ivo-Yankov
       - jasuwienas
       - konstantinabl
-      - lukelee-sl
-      - mwb-al
       - natanasow
       - quiet-node
-      - se7enarianelabs
       - simzzz
-      - victor-yanev
       - BartoszSolkaBD
       - bootcodes
   - name: hiero-json-rpc-relay-internal-contributors
     maintainers:
       - Ferparishuertas
-      - Nana-EC
     members:
       - tgntr
       - ValentinVPK
-      - SimiHunjan
   - name: hiero-json-rpc-relay-maintainers
     maintainers:
       - Ferparishuertas
-      - Nana-EC
     members:
-      - acuarica
       - konstantinabl
       - natanasow
       - quiet-node


### PR DESCRIPTION
Proposal to cull inactive permission holders (6+ months) in hiero json rpc relay

```
  - name: hiero-json-rpc-relay
    teams:
      github-maintainers: maintain
      hiero-automation: write
      hiero-json-rpc-relay-committers: write
      hiero-json-rpc-relay-internal-contributors: triage
      hiero-json-rpc-relay-maintainers: maintain
      hiero-triage: triage
      security-maintainers: triage
      tsc: maintain
```

these teams:
```
  - name: hiero-json-rpc-relay
    teams:
      hiero-json-rpc-relay-committers: write
      hiero-json-rpc-relay-internal-contributors: triage
      hiero-json-rpc-relay-maintainers: maintain
```
the rest retain similar access