### PR TITLE
chore: cull inactive permission holders hiero local node

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -721,7 +721,7 @@ teams:
       - Ivo-Yankov
       - Nana-EC
       - natanasow
-    members:
+    members: []
   - name: hiero-mirror-node-automation
     maintainers:
       - hedera-github-bot

--- a/config.yaml
+++ b/config.yaml
@@ -709,23 +709,18 @@ teams:
     members: []
   - name: hiero-local-node-committers
     maintainers:
-      - georgi-l95
       - Nana-EC
       - natanasow
     members:
-      - beeradb
       - Ivo-Yankov
       - konstantinabl
       - nathanklick
-      - Neeharika-Sompalli
-      - victor-yanev
   - name: hiero-local-node-maintainers
     maintainers:
       - Ivo-Yankov
       - Nana-EC
       - natanasow
     members:
-      - georgi-l95
   - name: hiero-mirror-node-automation
     maintainers:
       - hedera-github-bot

--- a/config.yaml
+++ b/config.yaml
@@ -715,6 +715,7 @@ teams:
       - Ivo-Yankov
       - konstantinabl
       - nathanklick
+      - Neeharika-Sompalli
   - name: hiero-local-node-maintainers
     maintainers:
       - Ivo-Yankov


### PR DESCRIPTION
Proposal to cull by inactivity (6+months) for this team in config.yml
```
  - name: hiero-local-node
    teams:
      github-maintainers: maintain
      hiero-local-node-automation: write
      hiero-local-node-committers: write
      hiero-local-node-maintainers: maintain
      hiero-triage: triage
      security-maintainers: triage
      tsc: maintain
    visibility: public
```
impacting:
```
  - name: hiero-local-node
    teams:
      hiero-local-node-committers: write
      hiero-local-node-maintainers: maintain
    visibility: public
```
rest retain similar acess