### PR TITLE
chore: cull inactive permission holders sdk collaboration hub

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1104,9 +1104,6 @@ teams:
       - exploreriii
       - gsstoykov
       - ivaylonikolov7
-      - nadineloepfe
-      - naydenovn
-      - RickyLB
       - venilinvasilev
     members:
       - 0xivanov
@@ -1114,7 +1111,6 @@ teams:
     maintainers:
       - hendrikebbers
       - rwalworth
-      - SimiHunjan
     members:
       - ddeskov-limechain
   - name: security-maintainers


### PR DESCRIPTION
Proposal to cull inactive permission holders (6+months) in sdk collaboration hub:
```
  - name: sdk-collaboration-hub
    teams:
      github-maintainers: maintain
      hiero-automation: write
      hiero-sdk-triage: triage
      sdk-collaboration-hub-committers: write
      sdk-collaboration-hub-maintainers: maintain
      security-maintainers: triage
      tsc: maintain
    visibility: public
```

just these teams:
```
  - name: sdk-collaboration-hub
    teams:
      sdk-collaboration-hub-committers: write
      sdk-collaboration-hub-maintainers: maintain
    visibility: public
```