### PR TITLE
chore: cull inactive permission holders roadmap

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1056,16 +1056,11 @@ teams:
       - a-saksena
       - steven-sheehy
     members:
-      - kfbr
-      - mahmoudian1
-      - poulok
-      - theekrystallee
   - name: roadmap-maintainers
     maintainers:
       - steven-sheehy
     members:
       - a-saksena
-      - rbair23
   - name: roadmap-viewers
     maintainers:
       - a-saksena


### PR DESCRIPTION
Proposal to cull inactive permission holders (6+months) in roadmap

```
  - name: roadmap
    teams:
      github-maintainers: maintain
      hiero-triage: write
      roadmap-committers: write
      roadmap-maintainers: maintain
      roadmap-viewers: read
      security-maintainers: triage
      tsc: maintain
```

just these teams:
```
  - name: roadmap
    teams:
      roadmap-committers: write
      roadmap-maintainers: maintain
```
