### PR TITLE
chore: cull inactive permission holders solo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1134,12 +1134,10 @@ teams:
       - nathanklick
     members:
       - jeromy-cannon
-      - leninmehedy
   - name: solo-committers
     maintainers:
       - jan-milenkov
       - jeromy-cannon
-      - leninmehedy
       - nathanklick
     members:
       - alex-kuzmin-hg
@@ -1149,20 +1147,17 @@ teams:
       - Fantomasa
       - Ivo-Yankov
       - JeffreyDallas
-      - matteriben
       - olsentorfinn
   - name: solo-docs-admins
     maintainers:
       - nathanklick
     members:
       - jeromy-cannon
-      - leninmehedy
   - name: solo-docs-committers
     maintainers:
       - deshmukhpranali
       - jeromy-cannon
       - nathanklick
-      - olsentorfinn
       - Reccetech
     members:
       - boris-bonin
@@ -1175,7 +1170,6 @@ teams:
       - jan-milenkov
       - jeromy-cannon
       - nathanklick
-      - olsentorfinn
       - Reccetech
       - JeffreyDallas
       - SimiHunjan
@@ -1184,7 +1178,6 @@ teams:
     maintainers:
       - jan-milenkov
       - jeromy-cannon
-      - leninmehedy
       - nathanklick
     members:
       - alex-kuzmin-hg
@@ -1201,7 +1194,6 @@ teams:
     members:
       - jan-milenkov
       - jeromy-cannon
-      - leninmehedy
   - name: tsc
     maintainers:
       - hendrikebbers


### PR DESCRIPTION
Proposal to cull inactive permission holders (6+months) in solo:
```
  - name: solo
    teams:
      github-maintainers: maintain
      hiero-automation: write
      hiero-triage: triage
      security-maintainers: triage
      solo-admins: admin
      solo-committers: write
      solo-internal-contributors: triage
      solo-maintainers: maintain
      tsc: maintain
    visibility: public
  - name: solo-docs
    teams:
      github-maintainers: maintain
      hiero-automation: write
      security-maintainers: triage
      solo-docs-admins: admin
      solo-docs-committers: write
      solo-docs-maintainers: maintain
      tsc: maintain
    visibility: public
```

impacting:
```
  - name: solo
    teams:
      solo-admins: admin
      solo-committers: write
      solo-internal-contributors: triage
      solo-maintainers: maintain
  - name: solo-docs
    teams:
      solo-docs-admins: admin
      solo-docs-committers: write
      solo-docs-maintainers: maintain
```