### PR TITLE
chore: cull inactive permission holders hiero hederium

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -569,9 +569,7 @@ teams:
       - nathanklick
   - name: hiero-hederium-maintainers
     maintainers:
-      - georgi-l95
     members:
-      - Dosik13
   - name: hiero-improvement-proposals-committers
     maintainers:
       - mgarbs


### PR DESCRIPTION
Proposal (draft) to cull inactive permission holders (6+ months) in hiero hederium
