### PR TITLE
chore: cull inactive permission holders solo-docs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1156,13 +1156,11 @@ teams:
       - nathanklick
     members:
       - jeromy-cannon
-      - leninmehedy
   - name: solo-docs-committers
     maintainers:
       - deshmukhpranali
       - jeromy-cannon
       - nathanklick
-      - olsentorfinn
       - Reccetech
     members:
       - boris-bonin
@@ -1175,7 +1173,6 @@ teams:
       - jan-milenkov
       - jeromy-cannon
       - nathanklick
-      - olsentorfinn
       - Reccetech
       - JeffreyDallas
       - SimiHunjan


### PR DESCRIPTION
Proposal to cull inactive permission holders (6+months) in solo:
```
  - name: solo-docs
    teams:
      github-maintainers: maintain
      hiero-automation: write
      security-maintainers: triage
      solo-docs-admins: admin
      solo-docs-committers: write
      solo-docs-maintainers: maintain
      tsc: maintain
    visibility: public
```

impacting:
```
  - name: solo-docs
    teams:
      solo-docs-admins: admin
      solo-docs-committers: write
      solo-docs-maintainers: maintain
```