### PR TITLE
chore: cull inactive permission holders solo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1134,12 +1134,10 @@ teams:
       - nathanklick
     members:
       - jeromy-cannon
-      - leninmehedy
   - name: solo-committers
     maintainers:
       - jan-milenkov
       - jeromy-cannon
-      - leninmehedy
       - nathanklick
     members:
       - alex-kuzmin-hg
@@ -1149,7 +1147,6 @@ teams:
       - Fantomasa
       - Ivo-Yankov
       - JeffreyDallas
-      - matteriben
       - olsentorfinn
   - name: solo-docs-admins
     maintainers:
@@ -1184,7 +1181,6 @@ teams:
     maintainers:
       - jan-milenkov
       - jeromy-cannon
-      - leninmehedy
       - nathanklick
     members:
       - alex-kuzmin-hg
@@ -1201,7 +1197,6 @@ teams:
     members:
       - jan-milenkov
       - jeromy-cannon
-      - leninmehedy
   - name: tsc
     maintainers:
       - hendrikebbers


### PR DESCRIPTION
Proposal to cull inactive permission holders (6+months) in solo:
```
  - name: solo
    teams:
      github-maintainers: maintain
      hiero-automation: write
      hiero-triage: triage
      security-maintainers: triage
      solo-admins: admin
      solo-committers: write
      solo-internal-contributors: triage
      solo-maintainers: maintain
      tsc: maintain
    visibility: public
```

impacting:
```
  - name: solo
    teams:
      solo-admins: admin
      solo-committers: write
      solo-internal-contributors: triage
      solo-maintainers: maintain
```