### PR TITLE
chore: culling inactive permission holders heka identity past 6 months

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -94,15 +94,11 @@ teams:
     maintainers:
       - AlexanderShenshin
     members:
-      - KononovAndrey
-      - paulo-caldas
       - tajang97
   - name: heka-identity-platform-maintainers
     maintainers:
       - AlexanderShenshin
     members:
-      - Artemkaaas
-      - ashcherbakov
       - Toktar
   - name: hiero-automation
     maintainers:


### PR DESCRIPTION
Proposal to remove permission holders that have been inactive in the last 6 months in heka identity
```
  - name: heka-identity-platform
    teams:
      github-maintainers: maintain
      heka-identity-platform-committers: write
      heka-identity-platform-maintainers: maintain
      security-maintainers: triage
      tsc: maintain
    visibility: public
```

impacting these teams:
```
  - name: heka-identity-platform
    teams:
      heka-identity-platform-committers: write
      heka-identity-platform-maintainers: maintain
```

rest retain access

in draft until a relevant voting team is created