### PR TITLE
chore: cull inactive permission holders hiero sdk js

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -850,7 +850,6 @@ teams:
       - mustafauzunn
   - name: hiero-sdk-js-committers
     maintainers:
-      - SimiHunjan
     members:
       - 0xivanov
       - agadzhalov
@@ -861,7 +860,6 @@ teams:
       - venilinvasilev
   - name: hiero-sdk-js-maintainers
     maintainers:
-      - SimiHunjan
     members:
       - agadzhalov
       - ivaylonikolov7


### PR DESCRIPTION
Proposal to cull inactive permission holders for js sdk

PR remains in draft as will be left without a maintainer, need to discuss a substitute if desired