### PR TITLE
chore: cull inactive permission holders block node

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -116,17 +116,11 @@ teams:
       - a-saksena
       - ata-nas
       - berryware
-      - CMiville42
-      - georgi-l95
       - ivannov
       - jasperpotts
       - jsync-swirlds
-      - mattp-swirldslabs
-      - mustafauzunn
-      - rbair23
       - rbarker-dev
       - rockysingh
-      - san-est
   - name: hiero-block-node-internal-contributors
     maintainers:
       - AlfredoG87
@@ -134,7 +128,6 @@ teams:
       - jsync-swirlds
       - Nana-EC
     members:
-      - SimiHunjan
   - name: hiero-block-node-maintainers
     maintainers:
       - Nana-EC

--- a/config.yaml
+++ b/config.yaml
@@ -116,9 +116,11 @@ teams:
       - a-saksena
       - ata-nas
       - berryware
+      - CMiville42
       - ivannov
       - jasperpotts
       - jsync-swirlds
+      - rbair23
       - rbarker-dev
       - rockysingh
   - name: hiero-block-node-internal-contributors
@@ -128,6 +130,7 @@ teams:
       - jsync-swirlds
       - Nana-EC
     members:
+      - SimiHunjan
   - name: hiero-block-node-maintainers
     maintainers:
       - Nana-EC


### PR DESCRIPTION
Proposal to cull inactive team members (6+ months) for hiero block node

in config.yml we have:
```
  - name: hiero-block-node
    teams:
      github-maintainers: maintain
      hiero-automation: write
      hiero-block-node-committers: write
      hiero-block-node-internal-contributors: triage
      hiero-block-node-maintainers: maintain
      hiero-gradle-conventions-maintainers: write
      hiero-triage: triage
      security-maintainers: triage
      tsc: maintain
```

this proposes to change the following teams, where inactivity is located:
```
  - name: hiero-block-node
    teams:
      hiero-block-node-committers: write
      hiero-block-node-internal-contributors: triage
      hiero-block-node-maintainers: maintain
```

This means a user may still have triage, write or maintain permissions despite being culled from the sublist, if they belong to github maintainers, hiero automation, hiero gradle conventions, hiero triage, security maintainers, tsc. Thus the net effect of this change to their abilities could in some cases be zero

Any proposed changes from maintainers or committers, please state below and I can reopen a vote with consensus