### PR TITLE
Add 'solo-build-actions' groups and repo to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1135,6 +1135,17 @@ teams:
     members:
       - jeromy-cannon
       - leninmehedy
+  - name: solo-build-actions
+    maintainers:
+      - jan-milenkov
+      - jeromy-cannon
+      - nathanklick
+    members:
+      - boris-bonin
+      - ddeskov-limechain
+      - Fantomasa
+      - Ivo-Yankov
+      - JeffreyDallas
   - name: solo-committers
     maintainers:
       - jan-milenkov
@@ -1602,6 +1613,18 @@ repositories:
       solo-committers: write
       solo-internal-contributors: triage
       solo-maintainers: maintain
+      tsc: maintain
+    visibility: public
+  - name: solo-build-actions
+    teams:
+      github-maintainers: maintain
+      hiero-automation: write
+      hiero-triage: triage
+      security-maintainers: triage
+      solo-admins: admin
+      solo-build-actions-committers: write
+      solo-internal-contributors: triage
+      solo-build-actions-maintainers: maintain
       tsc: maintain
     visibility: public
   - name: solo-docs

--- a/config.yaml
+++ b/config.yaml
@@ -1137,18 +1137,21 @@ teams:
       - leninmehedy
   - name: solo-build-actions-committers
     maintainers:
-      - boris-bonin
+      - jeromy-cannon
+      - nathanklick
+      - jan-milenkov
     members:
+      - boris-bonin
       - ddeskov-limechain
       - Fantomasa
       - Ivo-Yankov
       - JeffreyDallas
   - name: solo-build-actions-maintainers
     maintainers:
-      - jan-milenkov
-    members:
       - jeromy-cannon
       - nathanklick
+    members:
+      - jan-milenkov
   - name: solo-committers
     maintainers:
       - jan-milenkov

--- a/config.yaml
+++ b/config.yaml
@@ -1135,17 +1135,20 @@ teams:
     members:
       - jeromy-cannon
       - leninmehedy
-  - name: solo-build-actions
+  - name: solo-build-actions-committers
     maintainers:
-      - jan-milenkov
-      - jeromy-cannon
-      - nathanklick
-    members:
       - boris-bonin
+    members:
       - ddeskov-limechain
       - Fantomasa
       - Ivo-Yankov
       - JeffreyDallas
+  - name: solo-build-actions-maintainers
+    maintainers:
+      - jan-milenkov
+    members:
+      - jeromy-cannon
+      - nathanklick
   - name: solo-committers
     maintainers:
       - jan-milenkov


### PR DESCRIPTION
Added new repo 'solo-build-actions' with maintainers and members.
Fix: https://github.com/hiero-ledger/governance/issues/724

