### PR TITLE
Add Hendrik Ebbers nomination for Hiero TSC

### DIFF
--- a/elections/nominees/sep-2026-election/Hendrik-Ebbers.md
+++ b/elections/nominees/sep-2026-election/Hendrik-Ebbers.md
@@ -1,0 +1,28 @@
+# Nomination for Hiero TSC Maintainer seat
+ 
+## Candidate
+ 
+Hendrik Ebbers — @hendrikebbers
+Director of Open Source, Hashgraph
+
+## Qualifications
+ 
+Hendrik has served on the Hiero TSC since the project was founded, most recently as its Chair,
+and helped guide Hiero through its graduation as the first project under the LFDT Project Lifecycle Framework.
+In that time he established much of the governance the project runs on today:
+documented election and role definitions in the governance repo, transparent voting and minutes, a workable HIP process,
+and a maintainer structure that lets contributors grow into ownership.
+ 
+He contributes code and reviews across the project with a focus on the Java components, build and release tooling,
+and brought `hiero-enterprise-java` and `hiero-solo-action` into the Hiero organization as donated projects.
+He is a Java Champion, a member of the Eclipse Foundation Board of Directors, and Vice Chair of the LFDT Technical Advisory Board,
+where he represents Hiero's interests within the foundation.
+
+## Statement
+
+I would be glad to continue serving on the TSC. My priorities for the next term are the ones I have worked on so far:
+keeping Hiero genuinely vendor-neutral, lowering the barrier for new contributors and maintainers to take real ownership,
+and strengthening consistency across our SDK implementations.
+I also want the TSC to stay a body that decides transparently and in public — the governance work of the past year should become routine,
+not a one-time effort.
+ 


### PR DESCRIPTION
Added nomination details for Hendrik Ebbers for the Hiero TSC Maintainer seat, including qualifications and statement.