### PR TITLE
Nominate Piotr Swierzy for Hiero TSC

### DIFF
--- a/elections/nominees/sep-2026-election/Piotr-Swierzy.md
+++ b/elections/nominees/sep-2026-election/Piotr-Swierzy.md
@@ -1,0 +1,45 @@
+# Nomination for Hiero TSC Maintainer seat
+
+### Candidate
+
+Piotr Swierzy - [@piotrswierzy](https://github.com/piotrswierzy/)
+
+### Qualifications
+
+Piotr has been actively involved in the Hedera ecosystem for several years, working across protocol compatibility, developer tooling, ecosystem applications, technical research, and emerging use cases for the network.
+
+His work with Hedera started with building applications and infrastructure on top of the network, including contributing to the effort to port the 0x protocol from Ethereum to Hedera. This required close collaboration with Hedera engineering teams and hands-on work around EVM compatibility, smart contracts, JSON-RPC behavior, and differences between Ethereum and Hedera.
+
+Since then, Piotr and the teams he leads at BlockyDevs have contributed to a number of initiatives across the Hedera and Hiero ecosystem, including:
+
+* EVM compatibility and equivalence work, including testing Ethereum transaction behavior against Hedera and identifying compatibility issues in the consensus node and surrounding tooling.
+* Developer tooling and testing infrastructure for the Hedera ecosystem.
+* Work around the Hedera Agent Kit and tooling for AI agents interacting with Hedera.
+* Work with and analysis of newer Hedera protocol capabilities such as **HIP-551 Batch Transactions**, which introduced atomic execution of multiple dependent HAPI transactions and significantly expanded the types of workflows that can be implemented using Hedera's native services without relying on smart contracts.
+* Research and development around agentic commerce, machine-to-machine payments, x402, and how AI agents can securely transact using Hedera.
+* Integrations between Hedera and external wallets, applications, and infrastructure.
+* Technical education and community contributions, including presentations at Hiero Community Day and Hedera developer events.
+
+Piotr also leads **[BlockyResearch](https://blockyresearch.com/)**, a technical research initiative focused on explaining blockchain protocols from an engineering perspective. BlockyResearch has published hundreds of reports covering blockchain architecture, protocol mechanics, infrastructure, cryptography, payments, DeFi, AI agents, and the trade-offs behind different protocol designs.
+
+The research is produced by engineers who also design, test, and deploy blockchain systems, with the goal of making complex protocol-level decisions understandable to developers, founders, and technical decision-makers. Through BlockyResearch, Piotr combines hands-on engineering experience with continuous analysis of developments across the broader distributed-ledger ecosystem.
+
+Piotr combines hands-on technical experience with experience leading engineering teams working directly on production blockchain systems. His background spans smart contracts, EVM infrastructure, tokenization, payments, developer tooling, protocol research, and ecosystem applications.
+
+### Statement
+
+I would be honored to serve on the Hiero Technical Steering Committee.
+
+I have been working with Hedera for several years, and during that time my involvement has evolved from building applications on top of the network to working closely with teams developing its core infrastructure, developer tooling, integrations, and new use cases.
+
+What has kept me interested in Hedera and now Hiero is that the technology is genuinely different from many other distributed ledger platforms. Working on EVM compatibility, native Hedera services, developer tooling, and capabilities such as HIP-551 has given me an appreciation for both the opportunities created by this architecture and the complexity involved in evolving it without compromising stability, performance, or developer experience.
+
+I believe Hiero has a unique opportunity to become not only the open-source foundation behind Hedera, but a strong and independent open-source ecosystem in its own right. I would like to contribute to making that happen.
+
+On the TSC, I would particularly like to bring the perspective of developers and organizations building real-world applications on top of Hiero technology. I believe decisions about protocol architecture and developer tooling are strongest when they combine deep technical expertise with an understanding of how those decisions affect developers, integrators, and end users.
+
+My work with BlockyResearch has also reinforced how important it is to look beyond a single ecosystem. We continuously study the architecture and design decisions of other blockchain and distributed systems. I believe understanding why other protocols made different technical choices — and what worked or failed in practice — can provide valuable context when making long-term decisions for Hiero.
+
+I am also particularly interested in the intersection of distributed ledger technology, payments, and AI agents. I believe autonomous software and agentic commerce can become an important new category of applications, and Hiero is well positioned to provide infrastructure for identity, payments, tokenization, and verifiable interactions between those systems.
+
+I can commit the necessary time to actively participate in the TSC. I will approach discussions independently and neutrally, and I will prioritize the long-term technical health and success of the Hiero project over the interests of any individual company, contributor, or sub-project.


### PR DESCRIPTION
Self-nomination for a Hiero TSC Maintainer seat in the September 2026 election.

Adds `elections/nominees/sep-2026-election/Piotr-Swierzy.md`.

I approve this nomination.