### PR TITLE
chore: removed inactive users beeradb and tannerjfco from  hiero-consensus-node-devops-codeowners per request

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -230,14 +230,12 @@ teams:
       - dalvizu
     members:
       - allison-hashgraph
-      - beeradb
       - cweagans
       - ElijahLynn
       - kfbr
       - mahmoudian1
       - nirbosl
       - shezaan-hashgraph
-      - tannerjfco
   - name: hiero-consensus-node-execution-codeowners
     maintainers:
       - netopyr


### PR DESCRIPTION


**Description**:

- removed inactive users beeradb and tannerjfco from  hiero-consensus-node-devops-codeowners per request

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
