### PR TITLE
Security maintainer removal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1111,15 +1111,15 @@ teams:
   - name: security-maintainers
     maintainers:
       - nathanklick
+      - dr20240304
     members:
       - afaling0725
       - CMiville42
       - diogper
       - dr20240304
-      - mody-hashgraph
-      - NMiller-swirlds
-      - reachtobhavesh
       - VMN00B
+      - sinh3ck
+      - MukeshJaiswal01
   - name: solo-admins
     maintainers:
       - nathanklick

--- a/config.yaml
+++ b/config.yaml
@@ -1116,7 +1116,6 @@ teams:
       - afaling0725
       - CMiville42
       - diogper
-      - dr20240304
       - VMN00B
       - sinh3ck
       - MukeshJaiswal01


### PR DESCRIPTION
**Description**:

Updating security-maintainers team. Adding a new member in maintainers, removing people who left the team/org and adding new in members.