### PR TITLE
chore: add ddeskov-limechain and Fantomasa as committers for hiero-sdk-rust

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -890,6 +890,8 @@ teams:
       - RickyLB
     members:
       - agadzhalov
+      - ddeskov-limechain
+      - Fantomasa
       - ivaylonikolov7
   - name: hiero-sdk-rust-maintainers
     maintainers:


### PR DESCRIPTION
## Summary

This PR proposes adding two contributors as Committers for `hiero-sdk-rust`. A GitVote against this PR will be used to collect votes from the `hiero-sdk-rust-maintainers` team.

## Nominees

| Nominee | Basis | Existing Hiero roles |
|---|---|---|
| @ddeskov-limechain | Opened #1325 (ping/pingAll COST_ANSWER probe, AccountBalanceQuery deprecation Stage 1) and coordinates the change across the SDKs | Maintainer: hiero-sdk-swift, sdk-collaboration-hub. Committer: hiero-sdk-js, hiero-sdk-tck, solo |
| @Fantomasa | Merged #1326 (ping COST_ANSWER fix) and #1327 (Release v0.46.0); delivered the same fix in hiero-sdk-js (#4312) and hiero-sdk-swift (#652) | Committer: hiero-sdk-js, hiero-sdk-tck |

## Background

Both nominees work on the SDK consolidation effort and need write access to hiero-sdk-rust to drive cross-SDK changes and the Rust release process without depending on a maintainer for every step. Their track record in the other Hiero SDK repos is the basis for this nomination.

## Changes

- Add `ddeskov-limechain` to `hiero-sdk-rust-committers`
- Add `Fantomasa` to `hiero-sdk-rust-committers`

## Vote

To start the vote, a maintainer should comment:

```
/vote-hieroSdkRustMaintainers
```

Binding voters: members of `hiero-sdk-rust-maintainers`. Passing threshold: 66.66%, 2-week window.
